### PR TITLE
Normalize string to avoid two translatable strings

### DIFF
--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -598,7 +598,7 @@ FascistGecosUser(char *password, const char *user, const char *gecos)
 
 		if (GTry(longbuffer, password))
 		{
-		   return _("it's derived from your password entry");
+		   return _("it is derived from your password entry");
 		}
 	    }
 


### PR DESCRIPTION
https://github.com/cracklib/cracklib/blob/master/src/lib/fascist.c#L613
https://github.com/cracklib/cracklib/blob/master/src/lib/fascist.c#L625

minor change to use same sentence 