### PR TITLE
Force grep to treat the input as text when formatting word files

### DIFF
--- a/src/util/cracklib-format
+++ b/src/util/cracklib-format
@@ -4,7 +4,7 @@
 # into cracklib-packer
 #
 gzip -cdf "$@" |
-    grep -v '^\(#\|$\)' |
+    grep -a -v '^\(#\|$\)' |
     tr '[A-Z]' '[a-z]' |
     tr -cd '\012[a-z][0-9]' |
     env LC_ALL=C sort -u


### PR DESCRIPTION
Signed-off-by: Stefan Sørensen <stefan.sorensen@spectralink.com>
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/cracklib/0003-Force-grep-to-treat-the-input-as-text-when-formattin.patch]