### PR TITLE
util/Makefile.am: fix link with lintl

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -9,7 +9,7 @@ LDADD = ../lib/libcrack.la
 AM_CPPFLAGS = -I. -I.. -I$(top_srcdir)/lib '-DDEFAULT_CRACKLIB_DICT="$(DEFAULT_CRACKLIB_DICT)"' -Wall
 
 cracklib_check_SOURCES = check.c
-cracklib_check_LDADD = $(LDADD)
+cracklib_check_LDADD = $(LDADD) $(LTLIBINTL)
 
 cracklib_packer_SOURCES = packer.c
 cracklib_packer_LDADD = $(LDADD)


### PR DESCRIPTION
Fixes:
 - http://autobuild.buildroot.org/results/a16b8ce12f01ad37a2174422e39465b80108ff19

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>