### PR TITLE
lib/Makfiel.am: fix dynamic library version name from 2.9.0 to 2.9.8

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -14,7 +14,7 @@ libcrack_la_SOURCES = 	fascist.c \
 # For next ABI changing release, use 3:0:0
 # After that, follow the libtool recommended incrementing procedure
 #
-libcrack_la_LDFLAGS = -version-info 11:0:9
+libcrack_la_LDFLAGS = -version-info 11:8:9
 
 # Link in NLS libs. Needed by FreeBSD build
 libcrack_la_LIBADD = $(LTLIBINTL)


### PR DESCRIPTION
The danamic library name is always libcrack.so.2.9.0 and will not
change after the version is upgraded. It didn't meet the general
habit of dynamic library naming.

Signed-off-by: Yan Zhu <zhuyan34@huawei.com>