### PR TITLE
Fixes create-cracklib-dict warnings

### DIFF
--- a/src/util/cracklib-format
+++ b/src/util/cracklib-format
@@ -3,8 +3,17 @@
 # This preprocesses a set of word lists into a suitable form for input
 # into cracklib-packer
 #
+# Truncates lines longer than 1022 characters long as cracklib-packer
+# does not handle them correctly.
+#
+# The last part of the pipeline uses 'grep -v' to remove any blank
+# lines (possibly introduced by earlier parts of the pipeline) as
+# cracklib-packer will generate "skipping line" warnings otherwise.
+#
 gzip -cdf "$@" |
-    grep -a -v '^\(#\|$\)' |
+    grep -a -v '^#' |
     tr '[A-Z]' '[a-z]' |
     tr -cd '\012[a-z][0-9]' |
+    cut -c 1-1022 |
+    grep -v '^$' |
     env LC_ALL=C sort -u


### PR DESCRIPTION
With the distributed word files when "create-cracklib-dict" is run
it gives several output messages:

  skipping line: 1
  warning: input out of order

The "skipping line" message is due to the presence of a blank line
(after other line processing in cracklib-format).

The "input out of order" warnings are due to extremely long lines
present in the supplied myspace.txt.bz2 file - line 31,566 is 6341
characters long! cracklib-packer splits lines longer than 1022
characters long and treats them as distinct lines which then may
appear to be out of sort order due to the splitting.

Whilst the provided myspace.txt.bz2 file should be modified to remove
or truncate the very long line the same problem could appear for users
with other sourced word files.

This change truncates any lines from word files at 1022 characters and
ignores any blank lines.