### PR TITLE
cracklib: fix testnum and teststr failures

### DIFF
--- a/src/util/testnum.c
+++ b/src/util/testnum.c
@@ -20,7 +20,7 @@ main ()
     PWDICT *pwp;
     char buffer[STRINGSIZE];
 
-    if (!(pwp = PWOpen (NULL, "r")))
+    if (!(pwp = PWOpen (DEFAULT_CRACKLIB_DICT, "r")))
     {
 	perror ("PWOpen");
 	return (-1);

--- a/src/util/teststr.c
+++ b/src/util/teststr.c
@@ -15,7 +15,7 @@ main ()
     PWDICT *pwp;
     char buffer[STRINGSIZE];
 
-    if (!(pwp = PWOpen (NULL, "r")))
+    if (!(pwp = PWOpen (DEFAULT_CRACKLIB_DICT, "r")))
     {
 	perror ("PWOpen");
 	return (-1);


### PR DESCRIPTION
Error log:
...
$ ./testnum
(null).pwd.gz: No such file or directory
PWOpen: No such file or directory

$ ./util/teststr
(null).pwd.gz: No such file or directory
PWOpen: No such file or directory
...
Set DEFAULT_CRACKLIB_DICT as the path of  PWOpen

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>