### PR TITLE
util: Call bindtextdomain to initialise gettext

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -6,7 +6,7 @@ dist_sbin_SCRIPTS = create-cracklib-dict cracklib-format
 
 LDADD = ../lib/libcrack.la
 
-AM_CPPFLAGS = -I. -I.. -I$(top_srcdir)/lib '-DDEFAULT_CRACKLIB_DICT="$(DEFAULT_CRACKLIB_DICT)"' -Wall
+AM_CPPFLAGS = -I. -I.. -I$(top_srcdir)/lib '-DDEFAULT_CRACKLIB_DICT="$(DEFAULT_CRACKLIB_DICT)"' '-DLOCALEDIR="$(localedir)"' -Wall
 
 cracklib_check_SOURCES = check.c
 cracklib_check_LDADD = $(LDADD) $(LTLIBINTL)

--- a/src/util/check.c
+++ b/src/util/check.c
@@ -24,6 +24,7 @@ main(int argc, char **argv)
 	setlocale(LC_ALL, "");
 
 #ifdef ENABLE_NLS
+	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
 #endif
 


### PR DESCRIPTION
This fixes localised message output in the following cases:

* non-standard PREFIX on GNU systems

  GNU systems wouldn't be able to find the message catalog files.

* musl systems

  musl relies on bindtextdomain being called; it has no default catalog path.