### PR TITLE
Fix an issue that all words are deleted when there is no valid input data

### DIFF
--- a/src/util/packer.c
+++ b/src/util/packer.c
@@ -22,6 +22,7 @@ main(argc, argv)
     PWDICT *pwp;
     char buffer[STRINGSIZE], prev[STRINGSIZE];
     char *file;
+    char opened = 0;
 
     if (argc <= 1)
     {
@@ -36,12 +37,6 @@ main(argc, argv)
     {
 	fprintf(stderr, "Usage:\t%s dbname\n", argv[0]);
         fprintf(stderr, "  if dbname is not specified, will use compiled in default of (%s).\n", DEFAULT_CRACKLIB_DICT);
-	return (-1);
-    }
-
-    if (!(pwp = PWOpen(file, "w")))
-    {
-	perror(file);
 	return (-1);
     }
 
@@ -62,6 +57,16 @@ main(argc, argv)
 	    continue;
 	}
 
+	if (!opened)
+	{
+	    if (!(pwp = PWOpen(file, "w")))
+	    {
+	        perror(file);
+	        return (-1);
+	    }
+	    opened = 1;
+	}
+
 	/*
 	 * If this happens, strcmp() in FindPW() in packlib.c will be unhappy.
 	 */
@@ -79,7 +84,8 @@ main(argc, argv)
 	wrote++;
     }
 
-    PWClose(pwp);
+    if (opened)
+        PWClose(pwp);
 
     printf("%lu %lu\n", readed, wrote);
 


### PR DESCRIPTION
Fix an issue that dict words in the file pw_dict are deleted when create-cracklib-dict or cracklib-packer has no valid input data.

For example:
Give an empty file or a file that does't exist or a file has no valid input words to create-cracklib-dict, all words in pw_dict are deleted. 
$ cracklib-create-dict test

Run cracklib-packer and press Enter, all words in pw_dict are deleted. 
$ cracklib-packer