### PR TITLE
python: ensure to call bindtextdomain before textdomain

### DIFF
--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -2,6 +2,7 @@ if BUILD_PYTHON
 python_PYTHON = cracklib.py test_cracklib.py
 pyexec_LTLIBRARIES = _cracklib.la
 AM_CFLAGS = -I$(top_srcdir)/lib -Wall
+AM_CPPFLAGS = '-DLOCALEDIR="$(localedir)"'
 _cracklib_la_LDFLAGS = -module -avoid-version $(top_builddir)/lib/libcrack.la
 DEFS += '-DDEFAULT_CRACKLIB_DICT="$(DEFAULT_CRACKLIB_DICT)"'
 DEFS += '-DPYTHON_H="python@PYTHON_VERSION@/Python.h"'

--- a/src/python/_cracklib.c
+++ b/src/python/_cracklib.c
@@ -135,6 +135,7 @@ _cracklib_FascistCheck(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	setlocale(LC_ALL, "");
 #ifdef ENABLE_NLS
+	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain("cracklib");
 #endif
 


### PR DESCRIPTION
split out from https://github.com/cracklib/cracklib/pull/50 , same thing but for python.