### PR TITLE
python: adjust include path for builddir

### DIFF
--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -22,7 +22,7 @@ from setuptools import setup, Extension
 extensions = [
     Extension("_cracklib",
         ["@srcdir@/_cracklib.c"],
-        include_dirs = ["@top_srcdir@/lib"],
+        include_dirs = ["@top_builddir@", "@top_srcdir@/lib"],
         libraries = ["crack"],
         library_dirs = ["@top_builddir@/lib/.libs"]),
 ]


### PR DESCRIPTION
We need this for config.h added by 2e0f854bada720ff4fbd13aed4f87087d466274d.