### PR TITLE
Make buffer static and avoid returning stack-allocated memory

### DIFF
--- a/src/lib/rules.c
+++ b/src/lib/rules.c
@@ -213,7 +213,7 @@ Purge(string, target)		/* returns pointer to a purged copy */
     char target;
 {
     char *ptr;
-    char area[STRINGSIZE];
+    static char area[STRINGSIZE];
     ptr = area;
     while (*string)
     {


### PR DESCRIPTION
The area array in the PolyPurge function was not marked static like in the other functions.