### PR TITLE
upstream fedora patches for cracklib

### DIFF
--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -55,7 +55,6 @@ static char *r_destructors[] = {
 
     "/?p@?p",                   /* purging out punctuation/symbols/junk */
     "/?s@?s",
-    "/?X@?X",
 
     /* attempt reverse engineering of password strings */
 
@@ -454,6 +453,12 @@ GTry(rawtext, password)
 	    continue;
 	}
 
+	if (len - strlen(mp) >= 3)
+	{
+	   /* purged too much */
+	   continue;
+	}
+
 #ifdef DEBUG
 	printf("%-16s = %-16s (destruct %s)\n", mp, rawtext, r_destructors[i]);
 #endif
@@ -478,6 +483,12 @@ GTry(rawtext, password)
 	if (!(mp = Mangle(rawtext, r_constructors[i], area)))
 	{
 	    continue;
+	}
+
+	if (len - strlen(mp) >= 3)
+	{
+	   /* purged too much */
+	   continue;
 	}
 
 #ifdef DEBUG
@@ -708,6 +719,7 @@ FascistLookUser(PWDICT *pwp, char *instring,
     char rpassword[STRINGSIZE];
     char area[STRINGSIZE];
     uint32_t notfound;
+    int len;
 
     notfound = PW_WORDS(pwp);
     /* already truncated if from FascistCheck() */
@@ -757,6 +769,7 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	return _("it is all whitespace");
     }
 
+    len = strlen(password);
     i = 0;
     ptr = password;
     while (ptr[0] && ptr[1])
@@ -768,10 +781,9 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	ptr++;
     }
 
-    /*  Change by Ben Karsin from ITS at University of Hawaii at Manoa.  Static MAXSTEP
-        would generate many false positives for long passwords. */
-    maxrepeat = 3+(0.09*strlen(password));
-    if (i > maxrepeat)
+    /*  We were still generating false positives for long passwords.
+	Just count systematic double as a single character. */
+    if (len - i < MINLEN)
     {
 	return _("it is too simplistic/systematic");
     }
@@ -804,6 +816,12 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	    continue;
 	}
 
+	if (len - strlen(a) >= 3)
+	{
+	   /* purged too much */
+	   continue;
+	}
+
 #ifdef DEBUG
 	printf("%-16s (dict)\n", a);
 #endif
@@ -824,6 +842,13 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	{
 	    continue;
 	}
+
+	if (len - strlen(a) >= 3)
+	{
+	   /* purged too much */
+	   continue;
+	}
+
 #ifdef DEBUG
 	printf("%-16s (reversed dict)\n", a);
 #endif

--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -36,8 +36,8 @@ typedef unsigned short uint16_t;
 #undef DEBUG
 #undef DEBUG2
 
-extern char *Reverse(char *buf);
-extern char *Lowercase(char *buf);
+extern char *Reverse(char *buf, char *area);
+extern char *Lowercase(char *buf, char *area);
 
 static char *r_destructors[] = {
     ":",                        /* noop - must do this to test raw word. */
@@ -439,6 +439,8 @@ GTry(rawtext, password)
     int i;
     int len;
     char *mp;
+    char area[STRINGSIZE];
+    char revarea[STRINGSIZE];
 
     /* use destructors to turn password into rawtext */
     /* note use of Reverse() to save duplicating all rules */
@@ -447,7 +449,7 @@ GTry(rawtext, password)
 
     for (i = 0; r_destructors[i]; i++)
     {
-	if (!(mp = Mangle(password, r_destructors[i])))
+	if (!(mp = Mangle(password, r_destructors[i], area)))
 	{
 	    continue;
 	}
@@ -462,10 +464,10 @@ GTry(rawtext, password)
 	}
 
 #ifdef DEBUG
-	printf("%-16s = %-16s (destruct %s reversed)\n", Reverse(mp), rawtext, r_destructors[i]);
+	printf("%-16s = %-16s (destruct %s reversed)\n", Reverse(mp, revarea), rawtext, r_destructors[i]);
 #endif
 
-	if (!strncmp(Reverse(mp), rawtext, len))
+	if (!strncmp(Reverse(mp, revarea), rawtext, len))
 	{
 	    return (1);
 	}
@@ -473,7 +475,7 @@ GTry(rawtext, password)
 
     for (i = 0; r_constructors[i]; i++)
     {
-	if (!(mp = Mangle(rawtext, r_constructors[i])))
+	if (!(mp = Mangle(rawtext, r_constructors[i], area)))
 	{
 	    continue;
 	}
@@ -520,7 +522,7 @@ FascistGecosUser(char *password, const char *user, const char *gecos)
 
     strncpy(tbuffer, gecos, STRINGSIZE);
     tbuffer[STRINGSIZE-1] = '\0';
-    strcpy(gbuffer, Lowercase(tbuffer));
+    Lowercase(tbuffer, gbuffer);
 
     wc = 0;
     ptr = gbuffer;
@@ -704,6 +706,7 @@ FascistLookUser(PWDICT *pwp, char *instring,
     char junk[STRINGSIZE];
     char *password;
     char rpassword[STRINGSIZE];
+    char area[STRINGSIZE];
     uint32_t notfound;
 
     notfound = PW_WORDS(pwp);
@@ -740,7 +743,7 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	return _("it does not contain enough DIFFERENT characters");
     }
 
-    strcpy(password, (char *)Lowercase(password));
+    strcpy(password, (char *)Lowercase(password, area));
 
     Trim(password);
 
@@ -796,7 +799,7 @@ FascistLookUser(PWDICT *pwp, char *instring,
     {
 	char *a;
 
-	if (!(a = Mangle(password, r_destructors[i])))
+	if (!(a = Mangle(password, r_destructors[i], area)))
 	{
 	    continue;
 	}
@@ -811,13 +814,13 @@ FascistLookUser(PWDICT *pwp, char *instring,
 	}
     }
 
-    strcpy(password, (char *)Reverse(password));
+    strcpy(password, (char *)Reverse(password, area));
 
     for (i = 0; r_destructors[i]; i++)
     {
 	char *a;
 
-	if (!(a = Mangle(password, r_destructors[i])))
+	if (!(a = Mangle(password, r_destructors[i], area)))
 	{
 	    continue;
 	}

--- a/src/lib/packer.h
+++ b/src/lib/packer.h
@@ -82,7 +82,7 @@ extern int PWClose(PWDICT *pwp);
 extern unsigned int FindPW(PWDICT *pwp, char *string);
 extern int PutPW(PWDICT *pwp, char *string);
 extern int PMatch(char *control, char *string);
-extern char *Mangle(char *input, char *control);
+extern char *Mangle(char *input, char *control, char *area);
 extern char Chop(char *string);
 extern char *Trim(char *string);
 extern char *FascistLook(PWDICT *pwp, char *instring);

--- a/src/lib/rules.c
+++ b/src/lib/rules.c
@@ -80,12 +80,12 @@ Suffix(myword, suffix)
 }
 
 char *
-Reverse(str)			/* return a pointer to a reversal */
+Reverse(str, area)			/* return a pointer to a reversal */
     char *str;
+    char *area;
 {
     int i;
     int j;
-    static char area[STRINGSIZE];
     j = i = strlen(str);
     while (*str)
     {
@@ -96,11 +96,11 @@ Reverse(str)			/* return a pointer to a reversal */
 }
 
 char *
-Uppercase(str)			/* return a pointer to an uppercase */
+Uppercase(str, area)			/* return a pointer to an uppercase */
     char *str;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*str)
     {
@@ -113,11 +113,11 @@ Uppercase(str)			/* return a pointer to an uppercase */
 }
 
 char *
-Lowercase(str)			/* return a pointer to an lowercase */
+Lowercase(str, area)			/* return a pointer to an lowercase */
     char *str;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*str)
     {
@@ -130,11 +130,11 @@ Lowercase(str)			/* return a pointer to an lowercase */
 }
 
 char *
-Capitalise(str)			/* return a pointer to an capitalised */
+Capitalise(str, area)			/* return a pointer to an capitalised */
     char *str;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
 
     while (*str)
@@ -149,11 +149,11 @@ Capitalise(str)			/* return a pointer to an capitalised */
 }
 
 char *
-Pluralise(string)		/* returns a pointer to a plural */
+Pluralise(string, area)		/* returns a pointer to a plural */
     char *string;
+    char *area;
 {
     int length;
-    static char area[STRINGSIZE];
     length = strlen(string);
     strcpy(area, string);
 
@@ -190,13 +190,13 @@ Pluralise(string)		/* returns a pointer to a plural */
 }
 
 char *
-Substitute(string, old, new)	/* returns pointer to a swapped about copy */
+Substitute(string, old, new, area)	/* returns pointer to a swapped about copy */
     char *string;
     char old;
     char new;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*string)
     {
@@ -208,12 +208,12 @@ Substitute(string, old, new)	/* returns pointer to a swapped about copy */
 }
 
 char *
-Purge(string, target)		/* returns pointer to a purged copy */
+Purge(string, target, area)		/* returns pointer to a purged copy */
     char *string;
     char target;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*string)
     {
@@ -370,13 +370,13 @@ PolyStrchr(string, class)
 }
 
 char *
-PolySubst(string, class, new)	/* returns pointer to a swapped about copy */
+PolySubst(string, class, new, area)	/* returns pointer to a swapped about copy */
     char *string;
     char class;
     char new;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*string)
     {
@@ -388,12 +388,12 @@ PolySubst(string, class, new)	/* returns pointer to a swapped about copy */
 }
 
 char *
-PolyPurge(string, class)	/* returns pointer to a purged copy */
+PolyPurge(string, class, area)	/* returns pointer to a purged copy */
     char *string;
     char class;
+    char *area;
 {
     char *ptr;
-    static char area[STRINGSIZE];
     ptr = area;
     while (*string)
     {
@@ -426,39 +426,40 @@ Char2Int(character)
 }
 
 char *
-Mangle(input, control)		/* returns a pointer to a controlled Mangle */
+Mangle(input, control, area)		/* returns a pointer to a controlled Mangle */
     char *input;
     char *control;
+    char *area;
 {
     int limit;
     char *ptr;
-    static char area[STRINGSIZE * 2] = {0};
     char area2[STRINGSIZE * 2] = {0};
     strcpy(area, input);
 
     for (ptr = control; *ptr; ptr++)
     {
+	strcpy(area2, area);
 	switch (*ptr)
 	{
 	case RULE_NOOP:
 	    break;
 	case RULE_REVERSE:
-	    strcpy(area, Reverse(area));
+	    Reverse(area2, area);
 	    break;
 	case RULE_UPPERCASE:
-	    strcpy(area, Uppercase(area));
+	    Uppercase(area2, area);
 	    break;
 	case RULE_LOWERCASE:
-	    strcpy(area, Lowercase(area));
+	    Lowercase(area2, area);
 	    break;
 	case RULE_CAPITALISE:
-	    strcpy(area, Capitalise(area));
+	    Capitalise(area2, area);
 	    break;
 	case RULE_PLURALISE:
-	    strcpy(area, Pluralise(area));
+	    Pluralise(area2, area);
 	    break;
 	case RULE_REFLECT:
-	    strcat(area, Reverse(area));
+	    strcat(area, Reverse(area, area2));
 	    break;
 	case RULE_DUPLICATE:
 	    strcpy(area2, area);
@@ -545,7 +546,6 @@ Mangle(input, control)		/* returns a pointer to a controlled Mangle */
 		    Debug(1, "Mangle: extract: weird argument in '%s'\n", control);
 		    return NULL;
 		}
-		strcpy(area2, area);
 		for (i = 0; length-- && area2[start + i]; i++)
 		{
 		    area[i] = area2[start + i];
@@ -616,10 +616,10 @@ Mangle(input, control)		/* returns a pointer to a controlled Mangle */
 		return NULL;
 	    } else if (ptr[1] != RULE_CLASS)
 	    {
-		strcpy(area, Purge(area, *(++ptr)));
+		Purge(area2, *(++ptr), area);
 	    } else
 	    {
-		strcpy(area, PolyPurge(area, ptr[2]));
+		PolyPurge(area2, ptr[2], area);
 		ptr += 2;
 	    }
 	    break;
@@ -630,11 +630,11 @@ Mangle(input, control)		/* returns a pointer to a controlled Mangle */
 		return NULL;
 	    } else if (ptr[1] != RULE_CLASS)
 	    {
-		strcpy(area, Substitute(area, ptr[1], ptr[2]));
+		Substitute(area2, ptr[1], ptr[2], area);
 		ptr += 2;
 	    } else
 	    {
-		strcpy(area, PolySubst(area, ptr[2], ptr[3]));
+		PolySubst(area2, ptr[2], ptr[3], area);
 		ptr += 3;
 	    }
 	    break;

--- a/src/util/cracklib-format
+++ b/src/util/cracklib-format
@@ -10,10 +10,12 @@
 # lines (possibly introduced by earlier parts of the pipeline) as
 # cracklib-packer will generate "skipping line" warnings otherwise.
 #
+LC_ALL=C
+export LC_ALL
 gzip -cdf "$@" |
     grep -a -v '^#' |
     tr '[A-Z]' '[a-z]' |
     tr -cd '\012[a-z][0-9]' |
     cut -c 1-1022 |
     grep -v '^$' |
-    env LC_ALL=C sort -u
+    sort -u


### PR DESCRIPTION
Based on fedora patch:

commit a483b3bf78a0430b819ee17033e97e481eb57731
Author: Tomas Mraz <tmraz@fedoraproject.org>
Date:   Wed Aug 21 15:36:05 2013 +0200

    fix the python module to work with compressed dictionaries (#972542)

    - fix various dictionary lookup errors (#986400, #986401)
    - make the library reentrant and fix compilation warnings