### PR TITLE
convert K&R function declarations to ANSI C

### DIFF
--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -5,6 +5,10 @@
  */
 
 #include "config.h"
+#ifdef HAVE_GETPWUID_R
+// Needed for LINE_MAX
+#define	_XOPEN_SOURCE 700
+#endif
 #include <sys/types.h>
 #include <errno.h>
 #include <limits.h>
@@ -432,9 +436,7 @@ static char *r_constructors[] = {
 };
 
 int
-GTry(rawtext, password)
-    char *rawtext;
-    char *password;
+GTry(char *rawtext, char *password)
 {
     int i;
     int len;
@@ -632,9 +634,7 @@ FascistGecosUser(char *password, const char *user, const char *gecos)
 }
 
 char *
-FascistGecos(password, uid)
-    char *password;
-    int uid;
+FascistGecos( char *password, int uid)
 {
     struct passwd *pwp;
     char *sbuffer = NULL;
@@ -834,19 +834,14 @@ FascistLookUser(PWDICT *pwp, char *instring,
 }
 
 char *
-FascistLook(pwp, instring)
-    PWDICT *pwp;
-    char *instring;
+FascistLook(PWDICT *pwp, char *instring)
 {
     return FascistLookUser(pwp, instring, NULL, NULL);
 }
 
 const char *
-FascistCheckUser(password, path, user, gecos)
-    const char *password;
-    const char *path;
-    const char *user;
-    const char *gecos;
+FascistCheckUser(const char *password, const char *path, const char *user,
+    const char *gecos)
 {
     PWDICT *pwp;
     char pwtrunced[STRINGSIZE];
@@ -884,15 +879,13 @@ FascistCheckUser(password, path, user, gecos)
 }
 
 const char *
-FascistCheck(password, path)
-    const char *password;
-    const char *path;
+FascistCheck(const char *password, const char *path)
 {
     return FascistCheckUser(password, path, NULL, NULL);
 }
 
 const char *
-GetDefaultCracklibDict()
+GetDefaultCracklibDict(void)
 {
     return DEFAULT_CRACKLIB_DICT;
 }

--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -5,10 +5,6 @@
  */
 
 #include "config.h"
-#ifdef HAVE_GETPWUID_R
-// Needed for LINE_MAX
-#define	_XOPEN_SOURCE 700
-#endif
 #include <sys/types.h>
 #include <errno.h>
 #include <limits.h>

--- a/src/lib/packlib.c
+++ b/src/lib/packlib.c
@@ -60,9 +60,7 @@ _PWIsBroken64(FILE *ifp)
 
 
 PWDICT *
-PWOpen(prefix, mode)
-    const char *prefix;
-    char *mode;
+PWOpen(const char *prefix, char *mode)
 {
     int use64 = 0;
     static PWDICT pdesc;
@@ -310,8 +308,7 @@ PWOpen(prefix, mode)
 }
 
 int
-PWClose(pwp)
-    PWDICT *pwp;
+PWClose(PWDICT *pwp)
 {
     if (pwp->header.pih_magic != PIH_MAGIC)
     {
@@ -371,9 +368,7 @@ PWClose(pwp)
 }
 
 int
-PutPW(pwp, string)
-    PWDICT *pwp;
-    char *string;
+PutPW(PWDICT *pwp, char *string)
 {
     if (!(pwp->flags & PFOR_WRITE))
     {
@@ -434,9 +429,7 @@ PutPW(pwp, string)
 }
 
 char *
-GetPW(pwp, number)
-    PWDICT *pwp;
-    uint32_t number;
+GetPW(PWDICT *pwp, uint32_t number)
 {
     uint32_t datum;
     register int i;
@@ -536,9 +529,7 @@ GetPW(pwp, number)
 }
 
 unsigned int
-FindPW(pwp, string)
-    PWDICT *pwp;
-    char *string;
+FindPW(PWDICT *pwp, char *string)
 {
     register uint32_t lwm;
     register uint32_t hwm;

--- a/src/lib/rules.c
+++ b/src/lib/rules.c
@@ -5,6 +5,7 @@
  */
 
 #include "config.h"
+#include <stdarg.h>
 #include <string.h>
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
@@ -16,22 +17,16 @@
 #define CRACK_TOUPPER(a)        (islower(a)?toupper(a):(a))
 #define STRCMP(a,b)             strcmp((a),(b))
 
+static void
+Debug(int val, char *fmt, ...)
+{
 #if 0
-static void
-Debug(val, a, b, c, d, e, f, g)
-    int val;
-    char *a, *b, *c, *d, *e, *f, *g;
-{
-    fprintf(stderr, a, b, c, d, e, f, g);
-}
-#else
-static void
-Debug(val, a, b, c, d, e, f, g)
-    int val;
-    char *a, *b, *c, *d, *e, *f, *g;
-{
-}
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
 #endif
+}
 
 #define RULE_NOOP	':'
 #define RULE_PREPEND	'^'
@@ -61,9 +56,7 @@ Debug(val, a, b, c, d, e, f, g)
 #define RULE_MLAST	')'
 
 int
-Suffix(myword, suffix)
-    char *myword;
-    char *suffix;
+Suffix(char *myword, char *suffix)
 {
     int i;
     int j;
@@ -80,8 +73,7 @@ Suffix(myword, suffix)
 }
 
 char *
-Reverse(str)			/* return a pointer to a reversal */
-    char *str;
+Reverse(char *str)			/* return a pointer to a reversal */
 {
     int i;
     int j;
@@ -96,8 +88,7 @@ Reverse(str)			/* return a pointer to a reversal */
 }
 
 char *
-Uppercase(str)			/* return a pointer to an uppercase */
-    char *str;
+Uppercase(char *str)			/* return a pointer to an uppercase */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -113,8 +104,7 @@ Uppercase(str)			/* return a pointer to an uppercase */
 }
 
 char *
-Lowercase(str)			/* return a pointer to an lowercase */
-    char *str;
+Lowercase(char *str)			/* return a pointer to an lowercase */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -130,8 +120,7 @@ Lowercase(str)			/* return a pointer to an lowercase */
 }
 
 char *
-Capitalise(str)			/* return a pointer to an capitalised */
-    char *str;
+Capitalise(char *str)			/* return a pointer to an capitalised */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -149,8 +138,7 @@ Capitalise(str)			/* return a pointer to an capitalised */
 }
 
 char *
-Pluralise(string)		/* returns a pointer to a plural */
-    char *string;
+Pluralise(char *string)		/* returns a pointer to a plural */
 {
     int length;
     static char area[STRINGSIZE];
@@ -190,10 +178,7 @@ Pluralise(string)		/* returns a pointer to a plural */
 }
 
 char *
-Substitute(string, old, new)	/* returns pointer to a swapped about copy */
-    char *string;
-    char old;
-    char new;
+Substitute(char *string, char old, char new)	/* returns pointer to a swapped about copy */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -208,9 +193,7 @@ Substitute(string, old, new)	/* returns pointer to a swapped about copy */
 }
 
 char *
-Purge(string, target)		/* returns pointer to a purged copy */
-    char *string;
-    char target;
+Purge(char *string, char target)		/* returns pointer to a purged copy */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -235,9 +218,7 @@ Purge(string, target)		/* returns pointer to a purged copy */
  */
 
 int
-MatchClass(class, input)
-    char class;
-    char input;
+MatchClass(char class, char input)
 {
     char c;
     int retval;
@@ -354,9 +335,7 @@ MatchClass(class, input)
 }
 
 char *
-PolyStrchr(string, class)
-    char *string;
-    char class;
+PolyStrchr(char *string, char class)
 {
     while (*string)
     {
@@ -370,10 +349,7 @@ PolyStrchr(string, class)
 }
 
 char *
-PolySubst(string, class, new)	/* returns pointer to a swapped about copy */
-    char *string;
-    char class;
-    char new;
+PolySubst(char *string, char class, char new)	/* returns pointer to a swapped about copy */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -388,9 +364,7 @@ PolySubst(string, class, new)	/* returns pointer to a swapped about copy */
 }
 
 char *
-PolyPurge(string, class)	/* returns pointer to a purged copy */
-    char *string;
-    char class;
+PolyPurge(char *string, char class)	/* returns pointer to a purged copy */
 {
     char *ptr;
     static char area[STRINGSIZE];
@@ -409,8 +383,7 @@ PolyPurge(string, class)	/* returns pointer to a purged copy */
 /* -------- BACK TO NORMALITY -------- */
 
 int
-Char2Int(character)
-    char character;
+Char2Int(char character)
 {
     if (isdigit(character))
     {
@@ -426,9 +399,7 @@ Char2Int(character)
 }
 
 char *
-Mangle(input, control)		/* returns a pointer to a controlled Mangle */
-    char *input;
-    char *control;
+Mangle(char *input, char *control)		/* returns a pointer to a controlled Mangle */
 {
     int limit;
     char *ptr;
@@ -815,9 +786,7 @@ Mangle(input, control)		/* returns a pointer to a controlled Mangle */
 }
 
 int
-PMatch(control, string)
-char *control;
-char *string;
+PMatch(char *control, char *string)
 {
     while (*string && *control)
     {

--- a/src/lib/stringlib.c
+++ b/src/lib/stringlib.c
@@ -13,8 +13,7 @@
 #include "packer.h"
 
 char
-Chop(string)
-    register char *string;
+Chop(register char *string)
 {
     register char c;
     register char *ptr;
@@ -30,8 +29,7 @@ Chop(string)
 }
 
 char *
-Trim(string)
-    register char *string;
+Trim(register char *string)
 {
     register char *ptr;
     for (ptr = string; *ptr; ptr++);
@@ -44,8 +42,7 @@ Trim(string)
 }
 
 char *
-Clone(string)
-    char *string;
+Clone(char *string)
 {
     register char *retval;
     retval = (char *) malloc(strlen(string) + 1);

--- a/src/util/check.c
+++ b/src/util/check.c
@@ -4,6 +4,9 @@
  * or its effect upon hardware or computer systems.
  */
 
+// Needed for LINE_MAX
+#define	_XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>

--- a/src/util/check.c
+++ b/src/util/check.c
@@ -4,9 +4,6 @@
  * or its effect upon hardware or computer systems.
  */
 
-// Needed for LINE_MAX
-#define	_XOPEN_SOURCE 700
-
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>

--- a/src/util/packer.c
+++ b/src/util/packer.c
@@ -13,9 +13,7 @@
 #include "packer.h"
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     unsigned long readed;
     unsigned long wrote;

--- a/src/util/unpacker.c
+++ b/src/util/unpacker.c
@@ -12,9 +12,7 @@
 #include "packer.h"
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     uint32_t i;
     PWDICT *pwp;


### PR DESCRIPTION
This trivial change converts function definitions to use ANSI C. Checked with `CFLAGS='-std=c99 -Werror=old-style-definition' ./configure && make` on Ubuntu 22.04.2 with GCC 11.4.0.