### PR TITLE
cracklib-check: improve output when checking passwords

### DIFF
--- a/src/doc/cracklib-check.8
+++ b/src/doc/cracklib-check.8
@@ -2,7 +2,7 @@
 .SH NAME
 cracklib\-check \- Check passwords using libcrack2
 .SH SYNOPSIS
-.B cracklib\-check
+.B cracklib\-check [\-h|\-\-no\-echo]
 .br
 
 .SH DESCRIPTION
@@ -11,11 +11,20 @@ takes a list of passwords from stdin and checks them via libcrack2's
 .BR FascistCheck (3)
 sub routine.
 
+.SH OPTIONS
+.TP 4
+.I \-\-no\-echo
+Don't echo the password which is ok to the terminal.
+.TP
+.I \-h, \-\-help
+Print help explaining the command line options.
+
 .SH RESULT
 .B cracklib\-check
 prints each checked password and the corresponding result of
 .BR FascistCheck (3)
 to stdout. The password and the result are separated by a colon.
+When \-\-no\-echo is specified, prints only the result if password is ok.
 
 .SH SEE ALSO
 .BR FascistCheck (3)


### PR DESCRIPTION
Add option --no-echo to cracklib-check, shutdown echoing when read password from the terminal. 
If --no-echo is not specified, echoing plaintext to the terminal is default as the same as before. 

Fix: #77

Before:
[root@localhost ~]# cracklib-check 
29fjosajf
29fjosajf: OK
jf8
jf8: it is WAY too short
^C
[root@localhost ~]#

[root@localhost ~]# cracklib-check < test 
alfdj22: OK
faj2: it is too short
2: it is WAY too short
af2: it is WAY too short
Tls02: it is too short
lfjj02rqka: OK
ajf0nfn: OK
[root@localhost ~]# 

After:
[root@localhost ~]# cracklib-check 
alfdj22
alfdj22: OK
dh2
dh2: it is WAY too short
^C
[root@localhost ~]# 

[root@localhost ~]# cracklib-check --no-echo
TestPwd12: it is based on a dictionary word
It is OK
[root@localhost ~]#  

[root@localhost ~]# cracklib-check --no-echo < test 
It is OK
faj2: it is too short
2: it is WAY too short
af2: it is WAY too short
Tls02: it is too short
It is OK
It is OK
[root@localhost ~]# 
