### PR TITLE
Remove support for reading 64-bit dictionaries

### DIFF
--- a/src/lib/packlib.c
+++ b/src/lib/packlib.c
@@ -74,7 +74,7 @@ PWOpen(const char *prefix, char *mode)
 
     pdesc = malloc(sizeof(*pdesc));
     if (pdesc == NULL)
-	return NULL;
+        return NULL;
 
     memset(pdesc, '\0', sizeof(*pdesc));
     memset(&pdesc64, '\0', sizeof(pdesc64));
@@ -85,55 +85,55 @@ PWOpen(const char *prefix, char *mode)
 
     if (mode[0] == 'r')
     {
-		pdesc->flags &= ~PFOR_USEZLIB;
-		/* first try the normal db file */
-		if (!(pdesc->dfp = fopen(dname, mode)))
-		{
+        pdesc->flags &= ~PFOR_USEZLIB;
+        /* first try the normal db file */
+        if (!(pdesc->dfp = fopen(dname, mode)))
+        {
 #ifdef HAVE_ZLIB_H
-			pdesc->flags |= PFOR_USEZLIB;
-			/* try extension .gz */
-			snprintf(dname, STRINGSIZE, "%s.pwd.gz", prefix);
-			if (!(pdesc->dfp = gzopen(dname, mode)))
-			{
-				perror(dname);
-				free(pdesc);
-				return NULL;
-			}
+            pdesc->flags |= PFOR_USEZLIB;
+            /* try extension .gz */
+            snprintf(dname, STRINGSIZE, "%s.pwd.gz", prefix);
+            if (!(pdesc->dfp = gzopen(dname, mode)))
+            {
+                    perror(dname);
+                    free(pdesc);
+                    return NULL;
+            }
 #else
-		perror(dname);
-		free(pdesc);
-		return NULL;
+            perror(dname);
+            free(pdesc);
+            return NULL;
 #endif
-		}
-	}
-	else
-	{
-		pdesc->flags &= ~PFOR_USEZLIB;
-		/* write mode: use fopen */
-		if (!(pdesc->dfp = fopen(dname, mode)))
-		{
-			perror(dname);
-			free(pdesc);
-			return NULL;
-		}
-	}
+        }
+    }
+    else
+    {
+        pdesc->flags &= ~PFOR_USEZLIB;
+        /* write mode: use fopen */
+        if (!(pdesc->dfp = fopen(dname, mode)))
+        {
+            perror(dname);
+            free(pdesc);
+            return NULL;
+        }
+    }
 
     if (!(pdesc->ifp = fopen(iname, mode)))
     {
 #ifdef HAVE_ZLIB_H
-		if (pdesc->flags & PFOR_USEZLIB)
-			gzclose(pdesc->dfp);
-		else
+        if (pdesc->flags & PFOR_USEZLIB)
+            gzclose(pdesc->dfp);
+        else
 #endif
-			fclose(pdesc->dfp);
-	perror(iname);
-	free(pdesc);
-	return NULL;
+            fclose(pdesc->dfp);
+        perror(iname);
+        free(pdesc);
+        return NULL;
     }
 
     if ((pdesc->wfp = fopen(wname, mode)))
     {
-	pdesc->flags |= PFOR_USEHWMS;
+        pdesc->flags |= PFOR_USEHWMS;
     }
 
     ifp = pdesc->ifp;
@@ -142,34 +142,34 @@ PWOpen(const char *prefix, char *mode)
 
     if (mode[0] == 'w')
     {
-	pdesc->flags |= PFOR_WRITE;
-	pdesc->header.pih_magic = PIH_MAGIC;
-	pdesc->header.pih_blocklen = NUMWORDS;
-	pdesc->header.pih_numwords = 0;
+        pdesc->flags |= PFOR_WRITE;
+        pdesc->header.pih_magic = PIH_MAGIC;
+        pdesc->header.pih_blocklen = NUMWORDS;
+        pdesc->header.pih_numwords = 0;
 
-	fwrite((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp);
+        fwrite((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp);
     } else
     {
-	pdesc->flags &= ~PFOR_WRITE;
+        pdesc->flags &= ~PFOR_WRITE;
 
-	if (!fread((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp))
-	{
-	    fprintf(stderr, "%s: error reading header\n", prefix);
+        if (!fread((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp))
+        {
+            fprintf(stderr, "%s: error reading header\n", prefix);
 
-	    fclose(ifp);
+            fclose(ifp);
 #ifdef HAVE_ZLIB_H
-		if (pdesc->flags & PFOR_USEZLIB)
-			gzclose(dfp);
-		else
+            if (pdesc->flags & PFOR_USEZLIB)
+                gzclose(dfp);
+            else
 #endif
-			fclose(dfp);
-	    if (wfp)
-	    {
-		fclose(wfp);
-	    }
-	    free(pdesc);
-	    return NULL;
-	}
+                fclose(dfp);
+            if (wfp)
+            {
+                fclose(wfp);
+            }
+            free(pdesc);
+            return NULL;
+        }
 
         if ((pdesc->header.pih_magic == 0) || (pdesc->header.pih_numwords == 0))
         {
@@ -181,16 +181,16 @@ PWOpen(const char *prefix, char *mode)
 
                 fclose(ifp);
 #ifdef HAVE_ZLIB_H
-				if (pdesc->flags & PFOR_USEZLIB)
-					gzclose(dfp);
-				else
+                if (pdesc->flags & PFOR_USEZLIB)
+                    gzclose(dfp);
+                else
 #endif
-					fclose(dfp);
-		if (wfp)
-		{
-			fclose(wfp);
-		}
-	        free(pdesc);
+                    fclose(dfp);
+                if (wfp)
+                {
+                        fclose(wfp);
+                }
+                free(pdesc);
                 return NULL;
             }
             if (pdesc64.header.pih_magic != PIH_MAGIC)
@@ -200,17 +200,17 @@ PWOpen(const char *prefix, char *mode)
 
                 fclose(ifp);
 #ifdef HAVE_ZLIB_H
-				if (pdesc->flags & PFOR_USEZLIB)
-					gzclose(dfp);
-				else
+                if (pdesc->flags & PFOR_USEZLIB)
+                    gzclose(dfp);
+                else
 #endif
-					fclose(dfp);
+                    fclose(dfp);
 
-		if (wfp)
-		{
-			fclose(wfp);
-		}
-	        free(pdesc);
+                if (wfp)
+                {
+                    fclose(wfp);
+                }
+                free(pdesc);
                 return NULL;
             }
             pdesc->header.pih_magic = pdesc64.header.pih_magic;
@@ -220,25 +220,25 @@ PWOpen(const char *prefix, char *mode)
             use64 = 1;
         }
 
-	if (pdesc->header.pih_magic != PIH_MAGIC)
-	{
-	    fprintf(stderr, "%s: magic mismatch\n", prefix);
+        if (pdesc->header.pih_magic != PIH_MAGIC)
+        {
+            fprintf(stderr, "%s: magic mismatch\n", prefix);
 
-	    fclose(ifp);
+            fclose(ifp);
 #ifdef HAVE_ZLIB_H
-		if (pdesc->flags & PFOR_USEZLIB)
-			gzclose(dfp);
-		else
+            if (pdesc->flags & PFOR_USEZLIB)
+                gzclose(dfp);
+            else
 #endif
-			fclose(dfp);
+                fclose(dfp);
 
-	    if (wfp)
-	    {
-		fclose(wfp);
-	    }
-	    free(pdesc);
-	    return NULL;
-	}
+            if (wfp)
+            {
+                fclose(wfp);
+            }
+            free(pdesc);
+            return NULL;
+        }
 
         if (pdesc->header.pih_numwords < 1)
         {
@@ -246,40 +246,40 @@ PWOpen(const char *prefix, char *mode)
 
             fclose(ifp);
 #ifdef HAVE_ZLIB_H
-			if (pdesc->flags & PFOR_USEZLIB)
-				gzclose(dfp);
-			else
+            if (pdesc->flags & PFOR_USEZLIB)
+                gzclose(dfp);
+            else
 #endif
-				fclose(dfp);
-	    if (wfp)
-	    {
-		fclose(wfp);
-	    }
-	    free(pdesc);
+                fclose(dfp);
+            if (wfp)
+            {
+                fclose(wfp);
+            }
+            free(pdesc);
             return NULL;
         }
 
-	if (pdesc->header.pih_blocklen != NUMWORDS)
-	{
-	    fprintf(stderr, "%s: size mismatch\n", prefix);
+        if (pdesc->header.pih_blocklen != NUMWORDS)
+        {
+            fprintf(stderr, "%s: size mismatch\n", prefix);
 
-	    fclose(ifp);
+            fclose(ifp);
 #ifdef HAVE_ZLIB_H
-		if (pdesc->flags & PFOR_USEZLIB)
-			gzclose(dfp);
-		else
+            if (pdesc->flags & PFOR_USEZLIB)
+                gzclose(dfp);
+            else
 #endif
-			fclose(dfp);
-		if (wfp)
-	    {
-		fclose(wfp);
-	    }
-	    free(pdesc);
-	    return NULL;
-	}
+                fclose(dfp);
+            if (wfp)
+            {
+                fclose(wfp);
+            }
+            free(pdesc);
+            return NULL;
+        }
 
-	if (pdesc->flags & PFOR_USEHWMS)
-	{
+        if (pdesc->flags & PFOR_USEHWMS)
+        {
             int i;
 
             if (use64)
@@ -294,16 +294,16 @@ PWOpen(const char *prefix, char *mode)
                 }
             }
             else if (fread(pdesc->hwms, 1, sizeof(pdesc->hwms), wfp) != sizeof(pdesc->hwms))
-	    {
-		pdesc->flags &= ~PFOR_USEHWMS;
-	    }
+            {
+                pdesc->flags &= ~PFOR_USEHWMS;
+            }
 #if DEBUG
             for (i=1; i<=0xff; i++)
             {
                 printf("hwm[%02x] = %d\n", i, pdesc->hwms[i]);
             }
 #endif
-	}
+        }
     }
 
     return (pdesc);
@@ -314,53 +314,53 @@ PWClose(PWDICT *pwp)
 {
     if (pwp->header.pih_magic != PIH_MAGIC)
     {
-	fprintf(stderr, "PWClose: close magic mismatch\n");
-	return (-1);
+        fprintf(stderr, "PWClose: close magic mismatch\n");
+        return (-1);
     }
 
     if (pwp->flags & PFOR_WRITE)
     {
-	pwp->flags |= PFOR_FLUSH;
-	PutPW(pwp, NULL);	/* flush last index if necess */
+        pwp->flags |= PFOR_FLUSH;
+        PutPW(pwp, NULL);        /* flush last index if necess */
 
-	if (fseek(pwp->ifp, 0L, 0))
-	{
-	    fprintf(stderr, "index magic fseek failed\n");
-	    free(pwp);
-	    return (-1);
-	}
+        if (fseek(pwp->ifp, 0L, 0))
+        {
+            fprintf(stderr, "index magic fseek failed\n");
+            free(pwp);
+            return (-1);
+        }
 
-	if (!fwrite((char *) &pwp->header, sizeof(pwp->header), 1, pwp->ifp))
-	{
-	    fprintf(stderr, "index magic fwrite failed\n");
-	    free(pwp);
-	    return (-1);
-	}
+        if (!fwrite((char *) &pwp->header, sizeof(pwp->header), 1, pwp->ifp))
+        {
+            fprintf(stderr, "index magic fwrite failed\n");
+            free(pwp);
+            return (-1);
+        }
 
-	if (pwp->flags & PFOR_USEHWMS)
-	{
-	    int i;
-	    for (i=1; i<=0xff; i++)
-	    {
-	    	if (!pwp->hwms[i])
-	    	{
-	    	    pwp->hwms[i] = pwp->hwms[i-1];
-	    	}
+        if (pwp->flags & PFOR_USEHWMS)
+        {
+            int i;
+            for (i=1; i<=0xff; i++)
+            {
+                if (!pwp->hwms[i])
+                {
+                    pwp->hwms[i] = pwp->hwms[i-1];
+                }
 #if DEBUG
-	    	printf("hwm[%02x] = %d\n", i, pwp->hwms[i]);
+                printf("hwm[%02x] = %d\n", i, pwp->hwms[i]);
 #endif
-	    }
-	    fwrite(pwp->hwms, 1, sizeof(pwp->hwms), pwp->wfp);
-	}
+            }
+            fwrite(pwp->hwms, 1, sizeof(pwp->hwms), pwp->wfp);
+        }
     }
 
     fclose(pwp->ifp);
 #ifdef HAVE_ZLIB_H
-	if (pwp->flags & PFOR_USEZLIB)
-		gzclose(pwp->dfp);
-	else
+    if (pwp->flags & PFOR_USEZLIB)
+        gzclose(pwp->dfp);
+    else
 #endif
-		fclose(pwp->dfp);
+        fclose(pwp->dfp);
     if (pwp->wfp)
     {
         fclose(pwp->wfp);
@@ -377,58 +377,58 @@ PutPW(PWDICT *pwp, char *string)
 {
     if (!(pwp->flags & PFOR_WRITE))
     {
-	return (-1);
+        return (-1);
     }
 
     if (string)
     {
-	strncpy(pwp->data_put[pwp->count], string, MAXWORDLEN);
-	pwp->data_put[pwp->count][MAXWORDLEN - 1] = '\0';
+        strncpy(pwp->data_put[pwp->count], string, MAXWORDLEN);
+        pwp->data_put[pwp->count][MAXWORDLEN - 1] = '\0';
 
-	pwp->hwms[string[0] & 0xff]= pwp->header.pih_numwords;
+        pwp->hwms[string[0] & 0xff]= pwp->header.pih_numwords;
 
-	++(pwp->count);
-	++(pwp->header.pih_numwords);
+        ++(pwp->count);
+        ++(pwp->header.pih_numwords);
 
     } else if (!(pwp->flags & PFOR_FLUSH))
     {
-	return (-1);
+        return (-1);
     }
 
     if ((pwp->flags & PFOR_FLUSH) || !(pwp->count % NUMWORDS))
     {
-	int i;
-	uint32_t datum;
-	register char *ostr;
+        int i;
+        uint32_t datum;
+        register char *ostr;
 
-	datum = (uint32_t) ftell(pwp->dfp);
+        datum = (uint32_t) ftell(pwp->dfp);
 
-	fwrite((char *) &datum, sizeof(datum), 1, pwp->ifp);
+        fwrite((char *) &datum, sizeof(datum), 1, pwp->ifp);
 
-	fputs(pwp->data_put[0], pwp->dfp);
-	putc(0, (FILE*) pwp->dfp);
+        fputs(pwp->data_put[0], pwp->dfp);
+        putc(0, (FILE*) pwp->dfp);
 
-	ostr = pwp->data_put[0];
+        ostr = pwp->data_put[0];
 
-	for (i = 1; i < NUMWORDS; i++)
-	{
-	    register int j;
-	    register char *nstr;
-	    nstr = pwp->data_put[i];
+        for (i = 1; i < NUMWORDS; i++)
+        {
+            register int j;
+            register char *nstr;
+            nstr = pwp->data_put[i];
 
-	    if (nstr[0])
-	    {
-		for (j = 0; ostr[j] && nstr[j] && (ostr[j] == nstr[j]); j++);
-		putc(j & 0xff, (FILE*) pwp->dfp);
-		fputs(nstr + j, pwp->dfp);
-	    }
-	    putc(0, (FILE*) pwp->dfp);
+            if (nstr[0])
+            {
+                for (j = 0; ostr[j] && nstr[j] && (ostr[j] == nstr[j]); j++);
+                putc(j & 0xff, (FILE*) pwp->dfp);
+                fputs(nstr + j, pwp->dfp);
+            }
+            putc(0, (FILE*) pwp->dfp);
 
-	    ostr = nstr;
-	}
+            ostr = nstr;
+        }
 
-	memset(pwp->data_put, '\0', sizeof(pwp->data_put));
-	pwp->count = 0;
+        memset(pwp->data_put, '\0', sizeof(pwp->data_put));
+        pwp->count = 0;
     }
     return (0);
 }
@@ -448,69 +448,69 @@ GetPW(PWDICT *pwp, uint32_t number)
 
     if (_PWIsBroken64(pwp->ifp))
     {
-       uint64_t datum64;
-       if (fseek(pwp->ifp, sizeof(struct pi_header64) + (thisblock * sizeof(uint64_t)), 0))
-       {
-           perror("(index fseek failed)");
-           return NULL;
-       }
+        uint64_t datum64;
+        if (fseek(pwp->ifp, sizeof(struct pi_header64) + (thisblock * sizeof(uint64_t)), 0))
+        {
+            perror("(index fseek failed)");
+            return NULL;
+        }
 
-       if (!fread((char *) &datum64, sizeof(datum64), 1, pwp->ifp))
-       {
-           perror("(index fread failed)");
-           return NULL;
-       }
-       datum = datum64;
+        if (!fread((char *) &datum64, sizeof(datum64), 1, pwp->ifp))
+        {
+            perror("(index fread failed)");
+            return NULL;
+        }
+        datum = datum64;
     } else {
-       if (fseek(pwp->ifp, sizeof(struct pi_header) + (thisblock * sizeof(uint32_t)), 0))
-       {
-           perror("(index fseek failed)");
-           return NULL;
-       }
+        if (fseek(pwp->ifp, sizeof(struct pi_header) + (thisblock * sizeof(uint32_t)), 0))
+        {
+            perror("(index fseek failed)");
+            return NULL;
+        }
 
-       if (!fread((char *) &datum, sizeof(datum), 1, pwp->ifp))
-       {
-           perror("(index fread failed)");
-           return NULL;
-       }
+        if (!fread((char *) &datum, sizeof(datum), 1, pwp->ifp))
+        {
+            perror("(index fread failed)");
+            return NULL;
+        }
     }
 
-	int r = 1;
+    int r = 1;
 #ifdef HAVE_ZLIB_H
-	if (pwp->flags & PFOR_USEZLIB)
-	{
-		r = gzseek(pwp->dfp, datum, 0);
-		if (r >= 0)
-			r = 0;
-	}
-	else
+    if (pwp->flags & PFOR_USEZLIB)
+    {
+        r = gzseek(pwp->dfp, datum, 0);
+        if (r >= 0)
+            r = 0;
+    }
+    else
 #endif
-		r = fseek(pwp->dfp, datum, 0);
+        r = fseek(pwp->dfp, datum, 0);
 
 
     if (r)
     {
-	perror("(data fseek failed)");
-	return NULL;
+        perror("(data fseek failed)");
+        return NULL;
     }
-	r = 0;
+    r = 0;
 
-        memset(buffer, 0, sizeof(buffer));
+    memset(buffer, 0, sizeof(buffer));
 #ifdef HAVE_ZLIB_H
-	if (pwp->flags & PFOR_USEZLIB)
-	{
-		r = gzread(pwp->dfp, buffer, sizeof(buffer));
-		if (r < 0)
-			r = 0;
-	}
-	else
+    if (pwp->flags & PFOR_USEZLIB)
+    {
+        r = gzread(pwp->dfp, buffer, sizeof(buffer));
+        if (r < 0)
+            r = 0;
+    }
+    else
 #endif
-		r = fread(buffer, 1, sizeof(buffer), pwp->dfp);
+        r = fread(buffer, 1, sizeof(buffer), pwp->dfp);
 
     if (!r)
     {
-	perror("(data fread failed)");
-	return NULL;
+        perror("(data fread failed)");
+        return NULL;
     }
 
     bptr = buffer;
@@ -521,13 +521,13 @@ GetPW(PWDICT *pwp, uint32_t number)
 
     for (i = 1; i < NUMWORDS; i++)
     {
-	nstr = pwp->data_get[i];
-	strcpy(nstr, ostr);
+        nstr = pwp->data_get[i];
+        strcpy(nstr, ostr);
 
-	ostr = nstr + *(bptr++);
-	while ((*(ostr++) = *(bptr++)));
+        ostr = nstr + *(bptr++);
+        while ((*(ostr++) = *(bptr++)));
 
-	ostr = nstr;
+        ostr = nstr;
     }
 
     return (pwp->data_get[number % NUMWORDS]);
@@ -543,30 +543,30 @@ FindPW(PWDICT *pwp, char *string)
     int idx;
 
 #if DEBUG
-fprintf(stderr, "look for (%s)\n", string);
+    fprintf(stderr, "look for (%s)\n", string);
 #endif
 
     if (pwp->flags & PFOR_USEHWMS)
     {
-	idx = string[0] & 0xff;
-    	lwm = idx ? pwp->hwms[idx - 1] : 0;
-    	hwm = pwp->hwms[idx];
+        idx = string[0] & 0xff;
+        lwm = idx ? pwp->hwms[idx - 1] : 0;
+        hwm = pwp->hwms[idx];
 
 #if DEBUG
-	fprintf(stderr, "idx = %d\n", idx);
-	fprintf(stderr, "lwm = %d,  hwm = %d\n", lwm, hwm);
+        fprintf(stderr, "idx = %d\n", idx);
+        fprintf(stderr, "lwm = %d,  hwm = %d\n", lwm, hwm);
 #endif
     } else
     {
-    	lwm = 0;
-    	hwm = PW_WORDS(pwp) - 1;
+        lwm = 0;
+        hwm = PW_WORDS(pwp) - 1;
     }
 
     /* if the high water mark is lower than the low water mark, something is screwed up */
     if ( hwm < lwm )
     {
-	lwm = 0;
-	hwm = PW_WORDS(pwp) - 1;
+        lwm = 0;
+        hwm = PW_WORDS(pwp) - 1;
     }
 
 #if DEBUG
@@ -575,57 +575,57 @@ fprintf(stderr, "look for (%s)\n", string);
 
     for (;;)
     {
-	int cmp;
+        int cmp;
 
-	middle = lwm + ((hwm - lwm + 1) / 2);
+        middle = lwm + ((hwm - lwm + 1) / 2);
 
 #if DEBUG
-	fprintf(stderr, "lwm = %lu,  middle = %lu,  hwm = %lu\n", lwm, middle, hwm);
+        fprintf(stderr, "lwm = %lu,  middle = %lu,  hwm = %lu\n", lwm, middle, hwm);
 #endif
 
-	this = GetPW(pwp, middle);
-	if ( ! this )
-	{
+        this = GetPW(pwp, middle);
+        if ( ! this )
+        {
 #if DEBUG
-		fprintf(stderr, "getpw returned null, returning null in FindPW\n");
+            fprintf(stderr, "getpw returned null, returning null in FindPW\n");
 #endif
-		return(PW_WORDS(pwp));
-	}
-	else
-	{
+            return(PW_WORDS(pwp));
+        }
+        else
+        {
 #if DEBUG
-		fprintf(stderr, "comparing %s against found %s\n", string, this);
+            fprintf(stderr, "comparing %s against found %s\n", string, this);
 #endif
-	}
-
-	cmp = strcmp(string, this);
-	if (cmp == 0)
-	{
-	    return(middle);
         }
 
-	if (cmp < 0)
-	{
-	    if (middle == lwm)
-	    {
+        cmp = strcmp(string, this);
+        if (cmp == 0)
+        {
+            return(middle);
+        }
+
+        if (cmp < 0)
+        {
+            if (middle == lwm)
+            {
 #if DEBUG 
-		fprintf(stderr, "at terminal subdivision from right, stopping search\n");
+                fprintf(stderr, "at terminal subdivision from right, stopping search\n");
 #endif
-		break;
-	    }
-	    hwm = middle - 1;
-	} 
-	else if (cmp > 0)
-	{
-	    if (middle == hwm)
-	    {
+                break;
+            }
+            hwm = middle - 1;
+        } 
+        else if (cmp > 0)
+        {
+            if (middle == hwm)
+            {
 #if DEBUG 
-		fprintf(stderr, "at terminal subdivision from left, stopping search\n");
+                fprintf(stderr, "at terminal subdivision from left, stopping search\n");
 #endif
-		break;
-	    }
-	    lwm = middle + 1;
-	} 
+                break;
+            }
+            lwm = middle + 1;
+        } 
     }
 
     return (PW_WORDS(pwp));


### PR DESCRIPTION
This does two things:

1. fixes whitespace in the packlib.c file (only) to be consistent rather than a mix of indentation levels and tabs/spaces
2. removes support for reading "broken" 64-bit dictionaries as per issue #79