### PR TITLE
Remove unused variable in fascist.c

### DIFF
--- a/src/lib/fascist.c
+++ b/src/lib/fascist.c
@@ -707,7 +707,7 @@ char *
 FascistLookUser(PWDICT *pwp, char *instring,
 		const char *user, const char *gecos)
 {
-    int i,maxrepeat;
+    int i;
     char *ptr;
     char *jptr;
     char junk[STRINGSIZE];


### PR DESCRIPTION
The maxrepeat variable in FascistLookUser is not used and so it was removed.  This helps address issue #8.