### PR TITLE
Enhance testing

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -3,6 +3,8 @@ sbin_SCRIPTS = cracklib-update
 
 check_PROGRAMS = testlib testnum teststr 
 check_DATA = testdict
+check_SCRIPTS = checkdict.sh
+TESTS = $(check_SCRIPTS)
 
 dist_sbin_SCRIPTS = create-cracklib-dict cracklib-format
 
@@ -29,9 +31,13 @@ teststr_SOURCES = teststr.c
 teststr_LDADD = $(LDADD)
 
 testdict: $(top_srcdir)/dicts/cracklib-small
-	cracklib-format "$<" | cracklib-packer "$@"
+	$(builddir)/cracklib-format "$<" | $(builddir)/cracklib-packer "$@"
 
-CLEANFILES = testdict.pwi testdict.pwd testdict.hwm
+checkdict.sh: testdict
+	echo '! $(builddir)/cracklib-format $(top_srcdir)/dicts/cracklib-small | $(builddir)/testlib $(builddir)/testdict | grep -c ": ok"' > "$@"
+	chmod +x "$@"
+
+CLEANFILES = testdict.pwi testdict.pwd testdict.hwm checkdict.sh
 
 EXTRA_DIST = $(sbin_SCRIPTS) $(sbin_PROGRAMS)
 

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -2,6 +2,7 @@ sbin_PROGRAMS = cracklib-packer cracklib-unpacker cracklib-check
 sbin_SCRIPTS = cracklib-update
 
 check_PROGRAMS = testlib testnum teststr 
+check_DATA = testdict
 
 dist_sbin_SCRIPTS = create-cracklib-dict cracklib-format
 
@@ -26,6 +27,11 @@ testnum_LDADD = $(LDADD)
 
 teststr_SOURCES = teststr.c
 teststr_LDADD = $(LDADD)
+
+testdict: $(top_srcdir)/dicts/cracklib-small
+	cracklib-format "$<" | cracklib-packer "$@"
+
+CLEANFILES = testdict.pwi testdict.pwd testdict.hwm
 
 EXTRA_DIST = $(sbin_SCRIPTS) $(sbin_PROGRAMS)
 

--- a/src/util/testlib.c
+++ b/src/util/testlib.c
@@ -13,9 +13,18 @@
 #include "packer.h"
 
 int
-main ()
+main (int argc, char *argv[])
 {
     char buffer[1024];
+    char *file;
+    if (argc <= 1)
+    {
+	file = DEFAULT_CRACKLIB_DICT;
+    }
+    else
+    {
+        file = argv[1];
+    }
 
     printf("enter potential passwords, one per line...\n");
 
@@ -25,7 +34,7 @@ main ()
 
 	Chop(buffer);
 
-	val = FascistCheck(buffer, NULL);
+	val = FascistCheck(buffer, file);
 
 	if (!val)
 	{

--- a/src/util/testnum.c
+++ b/src/util/testnum.c
@@ -14,13 +14,23 @@
 #include "packer.h"
 
 int
-main ()
+main (int argc, char *argv[])
 {
     uint32_t i;
     PWDICT *pwp;
     char buffer[STRINGSIZE];
+    char *file;
 
-    if (!(pwp = PWOpen (DEFAULT_CRACKLIB_DICT, "r")))
+    if (argc <= 1)
+    {
+	file = DEFAULT_CRACKLIB_DICT;
+    }
+    else
+    {
+        file = argv[1];
+    }
+
+    if (!(pwp = PWOpen (file, "r")))
     {
 	perror ("PWOpen");
 	return (-1);

--- a/src/util/teststr.c
+++ b/src/util/teststr.c
@@ -10,12 +10,22 @@
 #include "packer.h"
 
 int
-main ()
+main(int argc, char *argv[])
 {
     PWDICT *pwp;
     char buffer[STRINGSIZE];
+    char *file;
 
-    if (!(pwp = PWOpen (DEFAULT_CRACKLIB_DICT, "r")))
+    if (argc <= 1)
+    {
+	file = DEFAULT_CRACKLIB_DICT;
+    }
+    else
+    {
+        file = argv[1];
+    }
+
+    if (!(pwp = PWOpen (file, "r")))
     {
 	perror ("PWOpen");
 	return (-1);


### PR DESCRIPTION
This adds an automatic test to make sure that `cracklib` is working.  It creates a simple dictionary from the `cracklib-small` word list and then tests each of those words against the dictionary.  The expected result, of course, is that none of the words are judged to be "ok" by `cracklib` and that's what this test checks.  This addresses issue #83.  A separate PR will address the out-of-source (OOS) issues noted there.

As an example, running `make check` produces a `test-suite.log` file which contains this:
```
==========================================
   cracklib 2.9.12: util/test-suite.log
==========================================

# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0

```