### PR TITLE
Omit existing check test if cross-compiling

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -96,6 +96,7 @@ AM_CONDITIONAL(BUILD_PYTHON,[test "$build_python" = "yes"])
 
 dnl Handle local dict compiling properly
 AC_SUBST(CROSS_COMPILING, $cross_compiling)
+AM_CONDITIONAL([NOT_CROSS_COMPILING], [test "$cross_compiling" = "no"])
 
 AC_CONFIG_FILES([util/Makefile lib/Makefile doc/Makefile python/Makefile Makefile \
 		python/setup.py \

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -2,9 +2,11 @@ sbin_PROGRAMS = cracklib-packer cracklib-unpacker cracklib-check
 sbin_SCRIPTS = cracklib-update
 
 check_PROGRAMS = testlib testnum teststr 
+if NOT_CROSS_COMPILING
 check_DATA = testdict
 check_SCRIPTS = checkdict.sh
 TESTS = $(check_SCRIPTS)
+endif
 
 dist_sbin_SCRIPTS = create-cracklib-dict cracklib-format
 
@@ -32,12 +34,14 @@ teststr_LDADD = $(LDADD)
 
 testdict: $(top_srcdir)/dicts/cracklib-small
 	$(builddir)/cracklib-format "$<" | $(builddir)/cracklib-packer "$@"
-
 checkdict.sh: testdict
 	echo '! $(builddir)/cracklib-format $(top_srcdir)/dicts/cracklib-small | $(builddir)/testlib $(builddir)/testdict | grep -c ": ok"' > "$@"
 	chmod +x "$@"
 
+if NOT_CROSS_COMPILING
 CLEANFILES = testdict.pwi testdict.pwd testdict.hwm checkdict.sh
+endif
+
 
 EXTRA_DIST = $(sbin_SCRIPTS) $(sbin_PROGRAMS)
 


### PR DESCRIPTION
If cracklib is being cross-compiled, the resulting binaries probably don't run on the build machine.  For that reason, this changes the "make check" test to not attempt to run the test if the code is being cross-compiled.  This relates to #83.