### PR TITLE
Always save as little endian

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -15,11 +15,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
-AC_CHECK_HEADERS(unistd.h)
-AC_CHECK_HEADERS(fcntl.h)
-AC_CHECK_HEADERS(inttypes.h)
-AC_CHECK_HEADERS(stdint.h)
-AC_CHECK_HEADERS(pthread.h)
+AC_CHECK_HEADERS([unistd.h fcntl.h inttypes.h stdint.h pthread.h endian.h])
 
 AC_ARG_WITH([zlib],
    [AS_HELP_STRING([--without-zlib], [build without zlib support @<:@default=auto@:>@])])

--- a/src/lib/packer.h
+++ b/src/lib/packer.h
@@ -60,6 +60,7 @@ typedef struct
     int count;
     char data_put[NUMWORDS][MAXWORDLEN];
     char data_get[NUMWORDS][MAXWORDLEN];
+    char wrong_endian;
 } PWDICT;
 
 #define PW_WORDS(x) ((x)->header.pih_numwords)

--- a/src/lib/packlib.c
+++ b/src/lib/packlib.c
@@ -28,7 +28,9 @@
 #define STORE_ORDER_BE 1
 #define STORE_ORDER_LE 2
 
+#ifndef STORE_ORDER
 #define STORE_ORDER STORE_ORDER_LE
+#endif
 
 #if STORE_ORDER == STORE_ORDER_LE
 #if DEBUG

--- a/src/lib/packlib.c
+++ b/src/lib/packlib.c
@@ -16,10 +16,115 @@
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
+#ifdef HAVE_ENDIAN_H
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
+#include <endian.h>
+#endif
 #include "packer.h"
 
 #define DEBUG 0
 
+#define STORE_ORDER_BE 1
+#define STORE_ORDER_LE 2
+
+#define STORE_ORDER STORE_ORDER_LE
+
+#if STORE_ORDER == STORE_ORDER_LE
+#if DEBUG
+#warning "Choosing LITTLE ENDIAN"
+#endif
+#define STORE_32(x) htole32(x)
+#define STORE_16(x) htole16(x)
+#define FETCH_32(x, wrong) (wrong == 'n' ? le32toh(x) : be32toh(x))
+#define FETCH_16(x, wrong) (wrong == 'n' ? le16toh(x) : be16toh(x))
+#else
+#if DEBUG
+#warning "Choosing BIG ENDIAN"
+#endif
+#define STORE_32(x) htobe32(x)
+#define STORE_16(x) htobe16(x)
+#define FETCH_32(x, wrong) (wrong == 'n' ? be32toh(x) : le32toh(x))
+#define FETCH_16(x, wrong) (wrong == 'n' ? be16toh(x) : le16toh(x))
+#endif
+
+static size_t
+write_header(struct pi_header *header, void *ifp, char *wrong_endian)
+{
+    struct pi_header header_copy;
+    *wrong_endian = 'n';
+    header_copy.pih_magic = STORE_32(header->pih_magic);
+    header_copy.pih_numwords = STORE_32(header->pih_numwords);
+    header_copy.pih_blocklen = STORE_16(header->pih_blocklen);
+    header_copy.pih_pad = STORE_16(header->pih_pad);
+    return fwrite((char *) &header_copy, sizeof(header_copy), 1, ifp);
+}
+
+static size_t
+read_header(struct pi_header *header, void *ifp, char *wrong_endian)
+{
+    size_t retval;
+    struct pi_header header_copy;
+    *wrong_endian = '?';
+    retval = fread((char *) &header_copy, sizeof(header_copy), 1, ifp);
+    if (retval) {
+        if (FETCH_32(header_copy.pih_magic, 'n') == PIH_MAGIC) {
+            *wrong_endian = 'n';
+        } else if (FETCH_32(header_copy.pih_magic, 'y') == PIH_MAGIC) {
+            *wrong_endian = 'y';
+        }
+        header->pih_magic = FETCH_32(header_copy.pih_magic, *wrong_endian);
+        header->pih_numwords = FETCH_32(header_copy.pih_numwords, *wrong_endian);
+        header->pih_blocklen = FETCH_16(header_copy.pih_blocklen, *wrong_endian);
+        header->pih_pad = FETCH_16(header_copy.pih_pad, *wrong_endian);
+    }
+    return retval;
+}
+
+static size_t
+write_hwms(uint32_t hwms[256], void* wfp)
+{
+    uint32_t hwms_copy[256];
+    int i;
+    for (i = 0; i < 256; ++i) {
+        hwms_copy[i] = STORE_32(hwms[i]);
+    }
+    return fwrite(&hwms_copy, sizeof(hwms_copy), 1, wfp);
+}
+
+static size_t
+read_hwms(uint32_t hwms[256], void* wfp, char wrong_endian)
+{
+    size_t retval;
+    uint32_t hwms_copy[256];
+    int i;
+    retval = fread(&hwms_copy, sizeof(hwms_copy), 1, wfp);
+    if (retval) {
+        for (i = 0; i < 256; ++i) {
+            hwms[i] = FETCH_32(hwms_copy[i], wrong_endian);
+        }
+    }
+    return retval;
+}
+
+
+static size_t
+write_index(uint32_t index, void* ifp)
+{
+    index = STORE_32(index);
+    return fwrite(&index, sizeof(index), 1, ifp);
+}
+
+static size_t
+read_index(uint32_t* index, void* ifp, char wrong_endian)
+{
+    size_t retval;
+    retval = fread(index, sizeof(*index), 1, ifp);
+    if (retval) {
+        *index = FETCH_32(*index, wrong_endian);
+    }
+    return retval;
+}
 
 PWDICT *
 PWOpen(const char *prefix, char *mode)
@@ -28,9 +133,6 @@ PWOpen(const char *prefix, char *mode)
     char iname[STRINGSIZE];
     char dname[STRINGSIZE];
     char wname[STRINGSIZE];
-    void *dfp;
-    void *ifp;
-    void *wfp;
 
     pdesc = malloc(sizeof(*pdesc));
     if (pdesc == NULL)
@@ -95,36 +197,31 @@ PWOpen(const char *prefix, char *mode)
         pdesc->flags |= PFOR_USEHWMS;
     }
 
-    ifp = pdesc->ifp;
-    dfp = pdesc->dfp;
-    wfp = pdesc->wfp;
-
     if (mode[0] == 'w')
     {
         pdesc->flags |= PFOR_WRITE;
         pdesc->header.pih_magic = PIH_MAGIC;
         pdesc->header.pih_blocklen = NUMWORDS;
         pdesc->header.pih_numwords = 0;
-
-        fwrite((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp);
+        write_header(&pdesc->header, pdesc->ifp, &pdesc->wrong_endian);
     } else
     {
         pdesc->flags &= ~PFOR_WRITE;
 
-        if (!fread((char *) &pdesc->header, sizeof(pdesc->header), 1, ifp))
+        if (!read_header(&pdesc->header, pdesc->ifp, &pdesc->wrong_endian))
         {
             fprintf(stderr, "%s: error reading header\n", prefix);
 
-            fclose(ifp);
+            fclose(pdesc->ifp);
 #ifdef HAVE_ZLIB_H
             if (pdesc->flags & PFOR_USEZLIB)
-                gzclose(dfp);
+                gzclose(pdesc->dfp);
             else
 #endif
-                fclose(dfp);
-            if (wfp)
+                fclose(pdesc->dfp);
+            if (pdesc->wfp)
             {
-                fclose(wfp);
+                fclose(pdesc->wfp);
             }
             free(pdesc);
             return NULL;
@@ -134,17 +231,17 @@ PWOpen(const char *prefix, char *mode)
         {
             fprintf(stderr, "%s: magic mismatch\n", prefix);
 
-            fclose(ifp);
+            fclose(pdesc->ifp);
 #ifdef HAVE_ZLIB_H
             if (pdesc->flags & PFOR_USEZLIB)
-                gzclose(dfp);
+                gzclose(pdesc->dfp);
             else
 #endif
-                fclose(dfp);
+                fclose(pdesc->dfp);
 
-            if (wfp)
+            if (pdesc->wfp)
             {
-                fclose(wfp);
+                fclose(pdesc->wfp);
             }
             free(pdesc);
             return NULL;
@@ -154,16 +251,16 @@ PWOpen(const char *prefix, char *mode)
         {
             fprintf(stderr, "%s: invalid word count\n", prefix);
 
-            fclose(ifp);
+            fclose(pdesc->ifp);
 #ifdef HAVE_ZLIB_H
             if (pdesc->flags & PFOR_USEZLIB)
-                gzclose(dfp);
+                gzclose(pdesc->dfp);
             else
 #endif
-                fclose(dfp);
-            if (wfp)
+                fclose(pdesc->dfp);
+            if (pdesc->wfp)
             {
-                fclose(wfp);
+                fclose(pdesc->wfp);
             }
             free(pdesc);
             return NULL;
@@ -173,16 +270,16 @@ PWOpen(const char *prefix, char *mode)
         {
             fprintf(stderr, "%s: size mismatch\n", prefix);
 
-            fclose(ifp);
+            fclose(pdesc->ifp);
 #ifdef HAVE_ZLIB_H
             if (pdesc->flags & PFOR_USEZLIB)
-                gzclose(dfp);
+                gzclose(pdesc->dfp);
             else
 #endif
-                fclose(dfp);
-            if (wfp)
+                fclose(pdesc->dfp);
+            if (pdesc->wfp)
             {
-                fclose(wfp);
+                fclose(pdesc->wfp);
             }
             free(pdesc);
             return NULL;
@@ -190,7 +287,7 @@ PWOpen(const char *prefix, char *mode)
 
         if (pdesc->flags & PFOR_USEHWMS)
         {
-            if (fread(pdesc->hwms, 1, sizeof(pdesc->hwms), wfp) != sizeof(pdesc->hwms))
+            if (read_hwms(pdesc->hwms, pdesc->wfp, pdesc->wrong_endian) != sizeof(pdesc->hwms))
             {
                 pdesc->flags &= ~PFOR_USEHWMS;
             }
@@ -198,7 +295,7 @@ PWOpen(const char *prefix, char *mode)
             int i;
             for (i=1; i<=0xff; i++)
             {
-                printf("hwm[%02x] = %d\n", i, pdesc->hwms[i]);
+                fprintf(stderr, "hwm[%02x] = %d\n", i, pdesc->hwms[i]);
             }
 #endif
         }
@@ -228,7 +325,7 @@ PWClose(PWDICT *pwp)
             return (-1);
         }
 
-        if (!fwrite((char *) &pwp->header, sizeof(pwp->header), 1, pwp->ifp))
+        if (!write_header(&pwp->header, pwp->ifp, &pwp->wrong_endian))
         {
             fprintf(stderr, "index magic fwrite failed\n");
             free(pwp);
@@ -245,10 +342,10 @@ PWClose(PWDICT *pwp)
                     pwp->hwms[i] = pwp->hwms[i-1];
                 }
 #if DEBUG
-                printf("hwm[%02x] = %d\n", i, pwp->hwms[i]);
+                fprintf(stderr, "hwm[%02x] = %d\n", i, pwp->hwms[i]);
 #endif
             }
-            fwrite(pwp->hwms, 1, sizeof(pwp->hwms), pwp->wfp);
+            write_hwms(pwp->hwms, pwp->wfp);
         }
     }
 
@@ -296,12 +393,9 @@ PutPW(PWDICT *pwp, char *string)
     if ((pwp->flags & PFOR_FLUSH) || !(pwp->count % NUMWORDS))
     {
         int i;
-        uint32_t datum;
         register char *ostr;
 
-        datum = (uint32_t) ftell(pwp->dfp);
-
-        fwrite((char *) &datum, sizeof(datum), 1, pwp->ifp);
+        write_index((uint32_t)ftell(pwp->dfp), pwp->ifp);
 
         fputs(pwp->data_put[0], pwp->dfp);
         putc(0, (FILE*) pwp->dfp);
@@ -344,17 +438,23 @@ GetPW(PWDICT *pwp, uint32_t number)
 
     thisblock = number / NUMWORDS;
 
+#if DEBUG
+    fprintf(stderr, "seeking index at: 0x%lx\n", thisblock *sizeof(uint32_t));
+#endif
     if (fseek(pwp->ifp, sizeof(struct pi_header) + (thisblock * sizeof(uint32_t)), 0))
     {
         perror("(index fseek failed)");
         return NULL;
     }
 
-    if (!fread((char *) &datum, sizeof(datum), 1, pwp->ifp))
+    if (!read_index(&datum, pwp->ifp, pwp->wrong_endian))
     {
         perror("(index fread failed)");
         return NULL;
     }
+#if DEBUG
+    fprintf(stderr, "read index: 0x%x, wrong_endian = %c\n", datum, pwp->wrong_endian);
+#endif
 
     int r = 1;
 #ifdef HAVE_ZLIB_H
@@ -451,7 +551,7 @@ FindPW(PWDICT *pwp, char *string)
     }
 
 #if DEBUG
-    fprintf(stderr, "---- %lu, %lu ----\n", lwm, hwm);
+    fprintf(stderr, "---- %u, %u ----\n", lwm, hwm);
 #endif
 
     for (;;)
@@ -461,7 +561,7 @@ FindPW(PWDICT *pwp, char *string)
         middle = lwm + ((hwm - lwm + 1) / 2);
 
 #if DEBUG
-        fprintf(stderr, "lwm = %lu,  middle = %lu,  hwm = %lu\n", lwm, middle, hwm);
+        fprintf(stderr, "lwm = %u,  middle = %u,  hwm = %u\n", lwm, middle, hwm);
 #endif
 
         this = GetPW(pwp, middle);
@@ -489,24 +589,24 @@ FindPW(PWDICT *pwp, char *string)
         {
             if (middle == lwm)
             {
-#if DEBUG 
+#if DEBUG
                 fprintf(stderr, "at terminal subdivision from right, stopping search\n");
 #endif
                 break;
             }
             hwm = middle - 1;
-        } 
+        }
         else if (cmp > 0)
         {
             if (middle == hwm)
             {
-#if DEBUG 
+#if DEBUG
                 fprintf(stderr, "at terminal subdivision from left, stopping search\n");
 #endif
                 break;
             }
             lwm = middle + 1;
-        } 
+        }
     }
 
     return (PW_WORDS(pwp));

--- a/src/lib/rules.c
+++ b/src/lib/rules.c
@@ -75,15 +75,13 @@ Suffix(char *myword, char *suffix)
 char *
 Reverse(char *str, char *area)			/* return a pointer to a reversal */
 {
-    int i;
-    int j;
-    j = i = strlen(str);
+    area += strlen(str);
+    *area-- = '\0';
     while (*str)
     {
-	area[--i] = *str++;
+	 *area-- = *str++;
     }
-    area[j] = '\0';
-    return (area);
+    return (++area);
 }
 
 char *

--- a/src/lib/rules.c
+++ b/src/lib/rules.c
@@ -394,7 +394,7 @@ Mangle(char *input, char *control, char *area)		/* returns a pointer to a contro
 {
     int limit;
     char *ptr;
-    char area2[STRINGSIZE * 2] = {0};
+    char area2[STRINGSIZE * 2];
     strcpy(area, input);
 
     for (ptr = control; *ptr; ptr++)

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -1,10 +1,10 @@
 sbin_PROGRAMS = cracklib-packer cracklib-unpacker cracklib-check
 sbin_SCRIPTS = cracklib-update
 
-check_PROGRAMS = testlib testnum teststr 
+check_PROGRAMS = testlib testnum teststr make-bad-endian
 if NOT_CROSS_COMPILING
-check_DATA = testdict
-check_SCRIPTS = checkdict.sh
+check_DATA = testdict baddict
+check_SCRIPTS = both-endian.sh checkdict.sh
 TESTS = $(check_SCRIPTS)
 endif
 
@@ -32,14 +32,27 @@ testnum_LDADD = $(LDADD)
 teststr_SOURCES = teststr.c
 teststr_LDADD = $(LDADD)
 
+make_bad_endian_SOURCES = packer.c ../lib/packlib.c
+make_bad_endian_CPPFLAGS = -I. -I.. -I$(top_srcdir)/lib '-DDEFAULT_CRACKLIB_DICT="deleteme"' '-DLOCALEDIR="$(localedir)"' -DIN_CRACKLIB -Wall '-DSTORE_ORDER=STORE_ORDER_BE'
+
 testdict: $(top_srcdir)/dicts/cracklib-small
 	$(srcdir)/cracklib-format "$<" | $(builddir)/cracklib-packer "$@"
-checkdict.sh: testdict
+
+checkdict.sh:
 	echo '! $(srcdir)/cracklib-format $(top_srcdir)/dicts/cracklib-small | $(builddir)/testlib $(builddir)/testdict | grep -c ": ok"' > "$@"
 	chmod +x "$@"
 
+both-endian.sh:
+	echo '[ "$(echo 50000 |./testnum baddict)" = "$(echo 50000 |./testnum testdict)" ]' > "$@"
+	chmod +x "$@"
+
+baddict: $(top_srcdir)/dicts/cracklib-small
+	$(srcdir)/cracklib-format "$<" | $(builddir)/make-bad-endian "$@"
+
+
 if NOT_CROSS_COMPILING
-CLEANFILES = testdict.pwi testdict.pwd testdict.hwm checkdict.sh
+CLEANFILES = testdict.pwi testdict.pwd testdict.hwm \
+	baddict.pwi baddict.pwd baddict.hwm checkdict.sh both-endian.sh
 endif
 
 

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -33,9 +33,9 @@ teststr_SOURCES = teststr.c
 teststr_LDADD = $(LDADD)
 
 testdict: $(top_srcdir)/dicts/cracklib-small
-	$(builddir)/cracklib-format "$<" | $(builddir)/cracklib-packer "$@"
+	$(srcdir)/cracklib-format "$<" | $(builddir)/cracklib-packer "$@"
 checkdict.sh: testdict
-	echo '! $(builddir)/cracklib-format $(top_srcdir)/dicts/cracklib-small | $(builddir)/testlib $(builddir)/testdict | grep -c ": ok"' > "$@"
+	echo '! $(srcdir)/cracklib-format $(top_srcdir)/dicts/cracklib-small | $(builddir)/testlib $(builddir)/testdict | grep -c ": ok"' > "$@"
 	chmod +x "$@"
 
 if NOT_CROSS_COMPILING


### PR DESCRIPTION
This addresses #74 by:
1. always writing dictionary files as little-endian, although it can read either little-endian or big-endian files.
2. adding a test to verify that it can read from either endian
3. making two changes to yield performance gains to more than offset any performance loss from this change
4. fixing an earlier "make check" to have the correct directories