### PR TITLE
Update Make targets

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,17 +18,7 @@ all-local:
 	@echo =======================================================
 	@echo
 
-test: all
-	@echo
-	@echo =======================================================
-	@echo If you get an error when running 'make test' about a 
-	@echo missing pw_dict.pwd file, that indicates that the word
-	@echo list dictionary file has not been built. You need to
-	@echo at least run 'make install' and 'make dict' to install
-	@echo the dictionay.  See the README file for more details.
-	@echo =======================================================
-	@echo
-	util/cracklib-check < test-data
+test: check
 
 dict: all
 	if test "x$(CROSS_COMPILING)" = "xno" ; then \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,29 +9,6 @@ EXTRA_DIST = \
 
 AUTOMAKE_OPTIONS=dist-bzip2 dist-zip dist-xz
 
-all-local:
-	@echo
-	@echo =======================================================
-	@echo Be sure and obtain a large wordlist file and run
-	@echo 'make install' and 'make dict' to generate the word 
-	@echo list index file. See the README file for more details.
-	@echo =======================================================
-	@echo
-
 test: check
-
-dict: all
-	if test "x$(CROSS_COMPILING)" = "xno" ; then \
-		export PATH="$(top_builddir)/util:$$PATH" ; \
-		export LD_LIBRARY_PATH="$(top_builddir)/lib/.libs:$$LD_LIBRARY_PATH" ; \
-	fi ; \
-	create-cracklib-dict "$(srcdir)"/dicts/*
-
-dict-local: all
-	if test "x$(CROSS_COMPILING)" = "xno" ; then \
-		export PATH="$(top_builddir)/util:$$PATH" ; \
-		export LD_LIBRARY_PATH="$(top_builddir)/lib/.libs:$$LD_LIBRARY_PATH" ; \
-	fi ; \
-	cracklib-format "$(srcdir)"/dicts/* | cracklib-packer $(DESTDIR)/$(DEFAULT_CRACKLIB_DICT)
 
 ACLOCAL_AMFLAGS = -I m4

--- a/src/README
+++ b/src/README
@@ -11,10 +11,10 @@ The primary reason for the updated release was to apply bug fixes and
 get them distributed from some central place instead of trying to get all
 of the various repackagers to apply additional packages.
 
-BUILD/INSTALL NOTE: You must 'make dict', preferably after getting a large
-wordlist, after install. Otherwise it will not install the dictionaries.
-This is left as a manual step since on some systems generating the
-dictionary index can be time consuming.
+BUILD/INSTALL NOTE: You must invoke 'create-cracklib-dict', preferably after 
+getting a large wordlist, after install. Otherwise it will not install the 
+dictionaries.  This is left as a manual step since on some systems generating 
+the dictionary index can be time consuming.
 
 
 ============================


### PR DESCRIPTION
This removes the `dict` and `dict-local` targets because they are no longer needed and don't work under all circumstances, such as when cross-compiling or when building out-of-source.  That, then, required updating the README to tell users to use `create-cracklib-dict` instead and to remove the `all-local` target which just told the user to run `make dict`.  Finally, it also removes most of `make test` to make it simply a synonym for `make check`.  This fixes #87.