### PR TITLE
Simplify autogen.sh

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = m4 lib util po doc python dicts
+SUBDIRS = lib util po doc python dicts
 
 EXTRA_DIST = \
 		cracklib.spec.in \

--- a/src/autogen.sh
+++ b/src/autogen.sh
@@ -1,8 +1,4 @@
 #!/bin/sh -x
-autopoint -f
-cd m4
-echo EXTRA_DIST = *.m4 > Makefile.am
-cd ..
 autoreconf -f -i
 
 # Grab latest versions instead of what is bundled with autoconf

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -96,6 +96,6 @@ AM_CONDITIONAL([NOT_CROSS_COMPILING], [test "$cross_compiling" = "no"])
 
 AC_CONFIG_FILES([util/Makefile lib/Makefile doc/Makefile python/Makefile Makefile \
 		python/setup.py \
-		po/Makefile.in m4/Makefile dicts/Makefile cracklib.spec])
+		po/Makefile.in dicts/Makefile cracklib.spec])
 AC_OUTPUT
 


### PR DESCRIPTION
This follows up on the suggestion in #76 which points out that autoreconf automatically calls autopoint when it detects that gettext is in use.  Also, there is no need anything special for the m4 files since autoconf (and autoreconf) will already automatically take care of those, too.