### PR TITLE
Preserve special characters in cracklib-format

### DIFF
--- a/src/util/cracklib-format
+++ b/src/util/cracklib-format
@@ -15,7 +15,7 @@ export LC_ALL
 gzip -cdf "$@" |
     grep -a -v '^#' |
     tr '[A-Z]' '[a-z]' |
-    tr -cd '\012[a-z][0-9]' |
+    tr -cd '\n[:graph:]' |
     cut -c 1-1022 |
     grep -v '^$' |
     sort -u


### PR DESCRIPTION
The commit https://github.com/cracklib/cracklib/commit/54568719798c2ecc5f72d6ab608ad0681fc4ce7c removed including of special characters when preprocessing the wordlist via `cracklib-format`.

Before changes introduced in this PR, the `cracklib-format` called from `create-cracklib-dict` removed special characters from the wordlist and therefore `cracklib-check` with such dictionary was not able to correctly recognize inputs based on dictionary words.

To reproduce:

```
$ create-cracklib-dict /usr/share/dict/words
$ grep -E '\w*[^\w\s]\w*' /usr/share/dict/words | cracklib-check | grep ': OK'
2,4,5-t: OK
Aaron's-beard: OK
Adam's-needle: OK
adder's-grass: OK
...
```

Previously, this change was also applied to Fedora (f37) https://src.fedoraproject.org/rpms/cracklib/blob/f37/f/cracklib-2.9.6-simplistic.patch#_111.