### PR TITLE
Use OSByteOrder functions on Darwin

### DIFF
--- a/src/lib/packlib.c
+++ b/src/lib/packlib.c
@@ -22,6 +22,15 @@
 #define _DEFAULT_SOURCE
 #include <endian.h>
 #endif
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define be16toh OSSwapBigToHostInt16
+#define be32toh OSSwapBigToHostInt32
+#define htole16 OSSwapHostToLittleInt16
+#define htole32 OSSwapHostToLittleInt32
+#define le16toh OSSwapLittleToHostInt16
+#define le32toh OSSwapLittleToHostInt32
+#endif
 #include "packer.h"
 
 #define DEBUG 0


### PR DESCRIPTION
After https://github.com/cracklib/cracklib/commit/14d22080bc8dbebf18685c57572a3c8adc16e390, cracklib fails to build on Darwin due to use of size-specific functions from `endian.h` that aren’t available on Darwin. This PR restores support for Darwin by defining them in terms of their equivalents from `OSByteOrder.h`.