### PR TITLE
Fix build for various BSD flavors

### DIFF
--- a/src/lib/portable_endian.h
+++ b/src/lib/portable_endian.h
@@ -57,14 +57,30 @@
 
 #	include <sys/endian.h>
 
+/* Keep these definitions for compatibility. */
+#	ifndef be16toh
 #	define be16toh(x) betoh16(x)
+#	endif
+
+#	ifndef le16toh
 #	define le16toh(x) letoh16(x)
+#	endif
 
+#	ifndef be32toh
 #	define be32toh(x) betoh32(x)
-#	define le32toh(x) letoh32(x)
+#	endif
 
+#	ifndef le32toh
+#	define le32toh(x) letoh32(x)
+#	endif
+
+#	ifndef be64toh
 #	define be64toh(x) betoh64(x)
+#	endif
+
+#	ifndef le64toh
 #	define le64toh(x) letoh64(x)
+#	endif
 
 #elif defined(__WINDOWS__)
 


### PR DESCRIPTION
[bl]eXtoh series macros have been defined in various BSD flavors.

Fixes: 30fc562 ("Include portable_endian.h")

https://github.com/NetBSD/src/blob/4899054afd533952882729ef59a0fae9a3bb397d/sys/sys/endian.h#L176

 https://github.com/freebsd/freebsd-src/blob/818c7b769a4f7d3c8fecc4cf491f4e22ef816eba/sys/sys/_endian.h#L113 

https://github.com/DragonFlyBSD/DragonFlyBSD/blob/167a410d9720e60c8a92f4c69bb9a87d37572402/sys/sys/endian.h#L69