### PR TITLE
Adapt portable_endian.h for GNU/Hurd

### DIFF
--- a/src/lib/portable_endian.h
+++ b/src/lib/portable_endian.h
@@ -19,7 +19,7 @@
 
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__)
 
 #	include <endian.h>
 


### PR DESCRIPTION
It uses GNU libc, which provides `<endian.h>`.