### PR TITLE
Various Python improvements

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -69,7 +69,7 @@ AC_ARG_WITH(python,
 AS_HELP_STRING([--without-python],[Build a python module @<:@default=auto@:>@]),
 build_python=$withval,build_python=auto)
 if test "$build_python" != no ; then
-   AM_PATH_PYTHON(,,
+   AM_PATH_PYTHON([3.6],,
                   [if test "$build_python" != yes ; then
                       AC_MSG_WARN([python was not found, continuing])
                       build_python=no

--- a/src/python/_cracklib.c
+++ b/src/python/_cracklib.c
@@ -84,18 +84,12 @@ _cracklib_FascistCheck(PyObject *self, PyObject *args, PyObject *kwargs)
     candidate = NULL;
     dict = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|s", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|s:FascistCheck", keywords,
                                      &candidate, &dict))
     {
-        PyErr_SetString(PyExc_ValueError, "error parsing arguments");
         return NULL;
     }
 
-    if (candidate == NULL)
-    {
-        PyErr_SetString(PyExc_ValueError, "first argument was not a string!");
-        return NULL;
-    }
     if (dict != NULL)
     {
         if (dict[0] != '/')

--- a/src/python/_cracklib.c
+++ b/src/python/_cracklib.c
@@ -29,9 +29,6 @@
 #else
 #include <Python.h>
 #endif
-#if PY_MAJOR_VERSION >= 3
-#define IS_PY3K
-#endif
 #ifdef HAVE_PTHREAD_H
 #include <pthread.h>
 #endif
@@ -170,8 +167,6 @@ static char _cracklib_doc[] =
     "program or interpreter.\n"
 ;
 
-#ifdef IS_PY3K
-
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_cracklib",
@@ -184,26 +179,12 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyObject *
 PyInit__cracklib(void)
 
-#else
-#define INITERROR return
-
-void
-init_cracklib(void)
-#endif
 {
-#ifdef IS_PY3K
     PyObject *module = PyModule_Create(&moduledef);
-#else
-    PyObject *module = Py_InitModule3("_cracklib", _cracklibmethods, _cracklib_doc);
-#endif
     if (module == NULL)
-        INITERROR;
-#ifdef IS_PY3K
+        return NULL;
     return module;
-#endif
 }

--- a/src/python/_cracklib.c
+++ b/src/python/_cracklib.c
@@ -44,6 +44,10 @@
 #include <libintl.h>
 #endif
 
+#if PY_VERSION_HEX < 0x03060000
+#error The minimum Python required is 3.6
+#endif
+
 #ifdef HAVE_PTHREAD_H
 static pthread_mutex_t cracklib_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define LOCK() pthread_mutex_lock(&cracklib_mutex)

--- a/src/python/test_cracklib.py
+++ b/src/python/test_cracklib.py
@@ -17,55 +17,32 @@ class TestModuleFunctions(unittest.TestCase):
     DICTPATH = None
 
     def test_VeryFascistCheck(self):
-        try:
+        with self.assertRaises(ValueError):
             cracklib.VeryFascistCheck('test', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            pass
         try:
             cracklib.VeryFascistCheck('LhIRI6JXpKhUqBjT', dictpath=self.DICTPATH)
         except ValueError:
             self.fail('password should be good enough')
 
     def test_palindrome(self):
-        try:
+        with self.assertRaisesRegex(ValueError, 'is a palindrome'):
             cracklib.VeryFascistCheck('ot23#xyx#32to', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            e = sys.exc_info()[1]
-            self.assertEqual('is a palindrome', str(e))
 
     def test_same(self):
-        try:
+        with self.assertRaisesRegex(ValueError, 'is the same as the old one'):
             cracklib.VeryFascistCheck('test', 'test', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            e = sys.exc_info()[1]
-            self.assertEqual('is the same as the old one', str(e))
 
     def test_case_change(self):
-        try:
+        with self.assertRaisesRegex(ValueError, 'case changes only'):
             cracklib.VeryFascistCheck('test', 'TeSt', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            e = sys.exc_info()[1]
-            self.assertEqual('case changes only', str(e))
 
     def test_similar(self):
-        try:
+        with self.assertRaisesRegex(ValueError, 'is too similar to the old one'):
             cracklib.VeryFascistCheck('test12', 'test34', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            e = sys.exc_info()[1]
-            self.assertEqual('is too similar to the old one', str(e))
 
     def test_simple(self):
-        try:
+        with self.assertRaisesRegex(ValueError, 'is too simple'):
             cracklib.VeryFascistCheck('t3sx24', dictpath=self.DICTPATH)
-            self.fail('expected ValueError')
-        except ValueError:
-            e = sys.exc_info()[1]
-            self.assertEqual('is too simple', str(e))
 
     def test_simple_lower(self):
         for passwd in ['t' * i for i in range(

--- a/src/python/test_cracklib.py
+++ b/src/python/test_cracklib.py
@@ -8,8 +8,6 @@ import sys
 import unittest
 import cracklib
 
-__version__ = '2.8.19'
-
 tests = []
 
 
@@ -102,7 +100,7 @@ tests.append(TestModuleFunctions)
 
 def run(verbosity=1, repeat=1, use_dictpath=None):
     print(('cracklib is installed in: ' + os.path.dirname(__file__)))
-    print(('cracklib version: ' + __version__))
+    print(('cracklib version: ' + cracklib.__version__))
     print((sys.version))
 
     suite = unittest.TestSuite()

--- a/src/python/test_cracklib.py
+++ b/src/python/test_cracklib.py
@@ -11,24 +11,25 @@ import cracklib
 __version__ = '2.8.19'
 
 tests = []
-dictpath = None
 
 
 class TestModuleFunctions(unittest.TestCase):
+    DICTPATH = None
+
     def test_VeryFascistCheck(self):
         try:
-            cracklib.VeryFascistCheck('test', dictpath=dictpath)
+            cracklib.VeryFascistCheck('test', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             pass
         try:
-            cracklib.VeryFascistCheck('LhIRI6JXpKhUqBjT', dictpath=dictpath)
+            cracklib.VeryFascistCheck('LhIRI6JXpKhUqBjT', dictpath=self.DICTPATH)
         except ValueError:
             self.fail('password should be good enough')
 
     def test_palindrome(self):
         try:
-            cracklib.VeryFascistCheck('ot23#xyx#32to', dictpath=dictpath)
+            cracklib.VeryFascistCheck('ot23#xyx#32to', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             e = sys.exc_info()[1]
@@ -36,7 +37,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_same(self):
         try:
-            cracklib.VeryFascistCheck('test', 'test', dictpath=dictpath)
+            cracklib.VeryFascistCheck('test', 'test', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             e = sys.exc_info()[1]
@@ -44,7 +45,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_case_change(self):
         try:
-            cracklib.VeryFascistCheck('test', 'TeSt', dictpath=dictpath)
+            cracklib.VeryFascistCheck('test', 'TeSt', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             e = sys.exc_info()[1]
@@ -52,7 +53,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_similar(self):
         try:
-            cracklib.VeryFascistCheck('test12', 'test34', dictpath=dictpath)
+            cracklib.VeryFascistCheck('test12', 'test34', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             e = sys.exc_info()[1]
@@ -60,7 +61,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_simple(self):
         try:
-            cracklib.VeryFascistCheck('t3sx24', dictpath=dictpath)
+            cracklib.VeryFascistCheck('t3sx24', dictpath=self.DICTPATH)
             self.fail('expected ValueError')
         except ValueError:
             e = sys.exc_info()[1]
@@ -123,14 +124,13 @@ tests.append(TestModuleFunctions)
 
 
 def run(verbosity=1, repeat=1, use_dictpath=None):
-    global dictpath
     print(('cracklib is installed in: ' + os.path.dirname(__file__)))
     print(('cracklib version: ' + __version__))
     print((sys.version))
-    dictpath=use_dictpath
 
     suite = unittest.TestSuite()
     for cls in tests:
+        cls.DICTPATH = use_dictpath
         for _ in range(repeat):
             loader = unittest.TestLoader()
             suite.addTest(loader.loadTestsFromTestCase(cls))


### PR DESCRIPTION
- raise the version required to 3.6; as mentioned in https://github.com/cracklib/cracklib/issues/103#issuecomment-2353014970, it can be the time to bump the version to something more modern (still supporting not too long EOLed versions)
- simplify the C argument parsing of `FascistCheck`
- use more `unittest` facilities
- few more cleanups in test code

See the message of each commit for longer descriptions.